### PR TITLE
Complete rewrite of flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # node-red-buttonplus-menu
+**Complete rewrite**
+
 
 Notes:
-* Topics on Buttonplus device remain unchanged. Node red handles maintains the state of the menu
-* Topics follow this naming convention: https://github.com/koenhendriks/ha-button-plus/wiki/mqttstructure.md
+* Topics on Buttonplus device **are changed**. **MQTT** handles and maintains the state of the menu
+* Topics follow this naming convention: https://github.com/koenhendriks/ha-button-plus/wiki/mqttstructure.md <-- to be updated, page is added `buttonplus/<device>/button/<page>/<buttonID>/state`
 * Uses the following additional nodes:
   * node-red-contrib-home-assistant-websocket
 * Requires configuration of Node Red with [file based storage of variables](https://stevesnoderedguide.com/node-red-variables). [Read this](https://community.home-assistant.io/t/persistent-states-node-red/76174) when using the addon
@@ -11,7 +13,8 @@ Notes:
   * https://gathering.tweakers.net/forum/list_messages/2225490
 
 ## Contents of `node_red_menu.flow`
-![node-red-buttonplus-menu-node_red_menu flow](https://github.com/balk77/node-red-buttonplus-menu/assets/10166350/f3d03355-e091-4de2-8783-b7629eaf5abd)
+<img width="954" alt="Screenshot 2024-01-14 at 17 13 32" src="https://github.com/balk77/node-red-buttonplus-menu/assets/10166350/8583e361-bc71-4ce0-945b-2759a7be226a">
 
 ## Contents of `node_red_update_display.flow`
-![node-red-buttonplus-menu-node_red_update_display flow](https://github.com/balk77/node-red-buttonplus-menu/assets/10166350/d6bd88e3-5da6-47e0-ab0a-b91796e41f9c)
+<img width="678" alt="Screenshot 2024-01-14 at 17 16 32" src="https://github.com/balk77/node-red-buttonplus-menu/assets/10166350/ebca9cea-3545-4ae5-bfa6-902950640b46">
+

--- a/node_red_menu.flow
+++ b/node_red_menu.flow
@@ -1,1 +1,3296 @@
-[{"id":"fd2bb19b59cf119e","type":"subflow","name":"B+ MQTT to main","info":"","category":"","in":[{"x":80,"y":100,"wires":[{"id":"94a06ba2b812bfa9"}]}],"out":[],"env":[],"meta":{},"color":"#DDAA99"},{"id":"0184922774fbede3","type":"mqtt out","z":"fd2bb19b59cf119e","name":"value","topic":"","qos":"0","retain":"true","respTopic":"","contentType":"","userProps":"","correl":"","expiry":"","broker":"e6dbd5fb3f32ec20","x":730,"y":360,"wires":[]},{"id":"59db74a4adc9a31f","type":"change","z":"fd2bb19b59cf119e","name":"","rules":[{"t":"set","p":"payload","pt":"msg","to":"label","tot":"msg"}],"action":"","property":"","from":"","to":"","reg":false,"x":540,"y":300,"wires":[["9169f4d5de7f5aa2"]]},{"id":"9169f4d5de7f5aa2","type":"mqtt out","z":"fd2bb19b59cf119e","name":"title","topic":"","qos":"0","retain":"true","respTopic":"","contentType":"","userProps":"","correl":"","expiry":"","broker":"e6dbd5fb3f32ec20","x":730,"y":300,"wires":[]},{"id":"cf7dbf4993cc51d8","type":"mqtt out","z":"fd2bb19b59cf119e","name":"uom","topic":"","qos":"0","retain":"true","respTopic":"","contentType":"","userProps":"","correl":"","expiry":"","broker":"e6dbd5fb3f32ec20","x":730,"y":240,"wires":[]},{"id":"e477e4949ea48f65","type":"change","z":"fd2bb19b59cf119e","name":"","rules":[{"t":"set","p":"payload","pt":"msg","to":"uom","tot":"msg"}],"action":"","property":"","from":"","to":"","reg":false,"x":540,"y":240,"wires":[["cf7dbf4993cc51d8"]]},{"id":"e387eac66190fe70","type":"function","z":"fd2bb19b59cf119e","name":"concat uom","func":"var appendix='uom'\nmsg.topic = msg.topic.concat(appendix)\nreturn msg;","outputs":1,"noerr":0,"initialize":"","finalize":"","libs":[],"x":330,"y":240,"wires":[["e477e4949ea48f65"]]},{"id":"3c67118b2fe0bb35","type":"function","z":"fd2bb19b59cf119e","name":"concat label","func":"var appendix='label'\nmsg.topic = msg.topic.concat(appendix)\nreturn msg;","outputs":1,"timeout":"","noerr":0,"initialize":"","finalize":"","libs":[],"x":330,"y":300,"wires":[["59db74a4adc9a31f"]]},{"id":"849c57c4154e9b1c","type":"function","z":"fd2bb19b59cf119e","name":"concat value","func":"var appendix='value'\nmsg.topic = msg.topic.concat(appendix)\nreturn msg;","outputs":1,"timeout":"","noerr":0,"initialize":"","finalize":"","libs":[],"x":330,"y":360,"wires":[["0184922774fbede3"]]},{"id":"94a06ba2b812bfa9","type":"function","z":"fd2bb19b59cf119e","name":"set topic","func":"msg.topic = \"buttonplus/\"+msg.device+\"/display/\"+msg.displayitem+\"/\";\nreturn msg;","outputs":1,"timeout":0,"noerr":0,"initialize":"","finalize":"","libs":[],"x":140,"y":300,"wires":[["e387eac66190fe70","3c67118b2fe0bb35","849c57c4154e9b1c"]]},{"id":"6f1d57e2cbc01e62","type":"subflow","name":"Subflow 3","info":"","in":[],"out":[{"x":1060,"y":140,"wires":[{"id":"a2a8846f0794feff","port":0},{"id":"bcca388dc6277946","port":0}]}]},{"id":"5ac9e7ed77e0c0b3","type":"inject","z":"6f1d57e2cbc01e62","name":"Button: btn_1l 1","props":[{"p":"btn_click","v":"btn_1l","vt":"str"}],"repeat":"","crontab":"","once":false,"onceDelay":0.1,"topic":"","x":220,"y":140,"wires":[["a2a8846f0794feff"]]},{"id":"9fa8b7180c347238","type":"inject","z":"6f1d57e2cbc01e62","name":"Button: btn_1l 0","props":[{"p":"btn_release","v":"btn_1l","vt":"str"}],"repeat":"","crontab":"","once":false,"onceDelay":0.1,"topic":"","x":220,"y":180,"wires":[["bcca388dc6277946"]]},{"id":"1aa656f2a036d38e","type":"inject","z":"6f1d57e2cbc01e62","name":"Button: btn_2l 1","props":[{"p":"btn_click","v":"btn_2l","vt":"str"}],"repeat":"","crontab":"","once":false,"onceDelay":0.1,"topic":"","x":220,"y":240,"wires":[["a2a8846f0794feff"]]},{"id":"81cff602966bc05d","type":"inject","z":"6f1d57e2cbc01e62","name":"Button: btn_2l 0","props":[{"p":"btn_release","v":"btn_2l","vt":"str"}],"repeat":"","crontab":"","once":false,"onceDelay":0.1,"topic":"","x":220,"y":280,"wires":[["bcca388dc6277946"]]},{"id":"319c14d74d652fe5","type":"inject","z":"6f1d57e2cbc01e62","name":"Button: btn_3l 1","props":[{"p":"btn_click","v":"btn_3l","vt":"str"}],"repeat":"","crontab":"","once":false,"onceDelay":0.1,"topic":"","x":220,"y":340,"wires":[["a2a8846f0794feff"]]},{"id":"c166aa253f50ddb0","type":"inject","z":"6f1d57e2cbc01e62","name":"Button: btn_3l 0","props":[{"p":"btn_release","v":"btn_3l","vt":"str"}],"repeat":"","crontab":"","once":false,"onceDelay":0.1,"topic":"","x":220,"y":380,"wires":[["bcca388dc6277946"]]},{"id":"97303d6c530a4cf4","type":"inject","z":"6f1d57e2cbc01e62","name":"Button: btn_4l 1","props":[{"p":"btn_click","v":"btn_4l","vt":"str"}],"repeat":"","crontab":"","once":false,"onceDelay":0.1,"topic":"","x":220,"y":440,"wires":[["a2a8846f0794feff"]]},{"id":"348543d06bad8b76","type":"inject","z":"6f1d57e2cbc01e62","name":"Button: btn_4l 0","props":[{"p":"btn_release","v":"btn_4l","vt":"str"}],"repeat":"","crontab":"","once":false,"onceDelay":0.1,"topic":"","x":220,"y":480,"wires":[["bcca388dc6277946"]]},{"id":"f2e3296d8fb6794f","type":"inject","z":"6f1d57e2cbc01e62","name":"Button: btn_1r 1","props":[{"p":"btn_click","v":"btn_1r","vt":"str"}],"repeat":"","crontab":"","once":false,"onceDelay":0.1,"topic":"","x":440,"y":140,"wires":[["a2a8846f0794feff"]]},{"id":"9c595cc51d1d4661","type":"inject","z":"6f1d57e2cbc01e62","name":"Button: btn_1r 0","props":[{"p":"btn_release","v":"btn_1r","vt":"str"}],"repeat":"","crontab":"","once":false,"onceDelay":0.1,"topic":"","x":440,"y":180,"wires":[["bcca388dc6277946"]]},{"id":"3bdbe06be6ccc563","type":"inject","z":"6f1d57e2cbc01e62","name":"Button: btn_2r 1","props":[{"p":"btn_click","v":"btn_2r","vt":"str"}],"repeat":"","crontab":"","once":false,"onceDelay":0.1,"topic":"","x":440,"y":240,"wires":[["a2a8846f0794feff"]]},{"id":"45a9e96cdd60e28b","type":"inject","z":"6f1d57e2cbc01e62","name":"Button: btn_2r 0","props":[{"p":"btn_release","v":"btn_2r","vt":"str"}],"repeat":"","crontab":"","once":false,"onceDelay":0.1,"topic":"","x":440,"y":280,"wires":[["bcca388dc6277946"]]},{"id":"fff1eb9cbf7d5334","type":"inject","z":"6f1d57e2cbc01e62","name":"Button: btn_3r 1","props":[{"p":"btn_click","v":"btn_3r","vt":"str"}],"repeat":"","crontab":"","once":false,"onceDelay":0.1,"topic":"","x":440,"y":340,"wires":[["a2a8846f0794feff"]]},{"id":"87db043792e36c8d","type":"inject","z":"6f1d57e2cbc01e62","name":"Button: btn_3r 0","props":[{"p":"btn_release","v":"btn_3r","vt":"str"}],"repeat":"","crontab":"","once":false,"onceDelay":0.1,"topic":"","x":440,"y":380,"wires":[["bcca388dc6277946"]]},{"id":"4061ba1becd48a95","type":"inject","z":"6f1d57e2cbc01e62","name":"Button: btn_4r 1","props":[{"p":"btn_click","v":"btn_4r","vt":"str"}],"repeat":"","crontab":"","once":false,"onceDelay":0.1,"topic":"","x":440,"y":440,"wires":[["a2a8846f0794feff"]]},{"id":"e00228794de698d3","type":"inject","z":"6f1d57e2cbc01e62","name":"Button: btn_4r 0","props":[{"p":"btn_release","v":"btn_4r","vt":"str"}],"repeat":"","crontab":"","once":false,"onceDelay":0.1,"topic":"","x":440,"y":480,"wires":[["bcca388dc6277946"]]},{"id":"a2a8846f0794feff","type":"change","z":"6f1d57e2cbc01e62","name":"btn_click","rules":[{"t":"set","p":"action_type","pt":"msg","to":"click","tot":"str"}],"action":"","property":"","from":"","to":"","reg":false,"x":920,"y":140,"wires":[[]]},{"id":"bcca388dc6277946","type":"change","z":"6f1d57e2cbc01e62","name":"btn_release","rules":[{"t":"set","p":"action_type","pt":"msg","to":"release","tot":"str"}],"action":"","property":"","from":"","to":"","reg":false,"x":710,"y":580,"wires":[[]]},{"id":"f5a178e39a22095f","type":"mqtt in","z":"6f1d57e2cbc01e62","name":"","topic":"buttonplus/wk1/button/0/state","qos":"2","datatype":"auto-detect","broker":"e6dbd5fb3f32ec20","nl":false,"rap":true,"rh":0,"inputs":0,"x":310,"y":80,"wires":[["f85cf298afbc65d0"]]},{"id":"f85cf298afbc65d0","type":"change","z":"6f1d57e2cbc01e62","name":"","rules":[{"t":"set","p":"btn_click","pt":"msg","to":"0","tot":"str"}],"action":"","property":"","from":"","to":"","reg":false,"x":570,"y":80,"wires":[["a2a8846f0794feff"]]},{"id":"c701010083975b86","type":"inject","z":"6f1d57e2cbc01e62","name":"Button: btn_5l 1","props":[{"p":"btn_click","v":"btn_5l","vt":"str"}],"repeat":"","crontab":"","once":false,"onceDelay":0.1,"topic":"","x":220,"y":540,"wires":[["a2a8846f0794feff"]]},{"id":"735e67c0fd83513b","type":"inject","z":"6f1d57e2cbc01e62","name":"Button: btn_5l 0","props":[{"p":"btn_release","v":"btn_5l","vt":"str"}],"repeat":"","crontab":"","once":false,"onceDelay":0.1,"topic":"","x":220,"y":580,"wires":[["bcca388dc6277946"]]},{"id":"43405eb119666b0e","type":"inject","z":"6f1d57e2cbc01e62","name":"Button: btn_5r 1","props":[{"p":"btn_click","v":"btn_5r","vt":"str"}],"repeat":"","crontab":"","once":false,"onceDelay":0.1,"topic":"","x":440,"y":540,"wires":[["a2a8846f0794feff"]]},{"id":"8f9f03d39a125427","type":"inject","z":"6f1d57e2cbc01e62","name":"Button: btn_5r 0","props":[{"p":"btn_release","v":"btn_5r","vt":"str"}],"repeat":"","crontab":"","once":false,"onceDelay":0.1,"topic":"","x":440,"y":580,"wires":[["bcca388dc6277946"]]},{"id":"f645b4c8f4511a56","type":"mqtt in","z":"6f1d57e2cbc01e62","name":"","topic":"buttonplus/wk1/button/0/state","qos":"2","datatype":"auto-detect","broker":"e6dbd5fb3f32ec20","nl":false,"rap":true,"rh":0,"inputs":0,"x":270,"y":660,"wires":[["3b6d267456e57645"]]},{"id":"3b6d267456e57645","type":"change","z":"6f1d57e2cbc01e62","name":"","rules":[{"t":"set","p":"btn_click","pt":"msg","to":"payload","tot":"msg"}],"action":"","property":"","from":"","to":"","reg":false,"x":630,"y":740,"wires":[["a2a8846f0794feff"]]},{"id":"f53a89bafac8c79d","type":"mqtt in","z":"6f1d57e2cbc01e62","name":"","topic":"buttonplus/wk1/button/1/state","qos":"2","datatype":"auto-detect","broker":"e6dbd5fb3f32ec20","nl":false,"rap":true,"rh":0,"inputs":0,"x":270,"y":700,"wires":[["3b6d267456e57645"]]},{"id":"1b513fc0b2a628b3","type":"mqtt in","z":"6f1d57e2cbc01e62","name":"","topic":"buttonplus/wk1/button/2/state","qos":"2","datatype":"auto-detect","broker":"e6dbd5fb3f32ec20","nl":false,"rap":true,"rh":0,"inputs":0,"x":270,"y":740,"wires":[["3b6d267456e57645"]]},{"id":"8a38f53e095ea07c","type":"mqtt in","z":"6f1d57e2cbc01e62","name":"","topic":"buttonplus/wk1/button/3/state","qos":"2","datatype":"auto-detect","broker":"e6dbd5fb3f32ec20","nl":false,"rap":true,"rh":0,"inputs":0,"x":270,"y":780,"wires":[["3b6d267456e57645"]]},{"id":"1ddc2fac8b858f28","type":"mqtt in","z":"6f1d57e2cbc01e62","name":"","topic":"buttonplus/wk1/button/7/state","qos":"2","datatype":"auto-detect","broker":"e6dbd5fb3f32ec20","nl":false,"rap":true,"rh":0,"inputs":0,"x":270,"y":940,"wires":[["3b6d267456e57645"]]},{"id":"fff8705f5db88875","type":"mqtt in","z":"6f1d57e2cbc01e62","name":"","topic":"buttonplus/wk1/button/6/state","qos":"2","datatype":"auto-detect","broker":"e6dbd5fb3f32ec20","nl":false,"rap":true,"rh":0,"inputs":0,"x":270,"y":900,"wires":[["3b6d267456e57645"]]},{"id":"1901a58c9270cf5f","type":"mqtt in","z":"6f1d57e2cbc01e62","name":"","topic":"buttonplus/wk1/button/5/state","qos":"2","datatype":"auto-detect","broker":"e6dbd5fb3f32ec20","nl":false,"rap":true,"rh":0,"inputs":0,"x":270,"y":860,"wires":[["3b6d267456e57645"]]},{"id":"2d12bcc96a346c1a","type":"mqtt in","z":"6f1d57e2cbc01e62","name":"","topic":"buttonplus/wk1/button/4/state","qos":"2","datatype":"auto-detect","broker":"e6dbd5fb3f32ec20","nl":false,"rap":true,"rh":0,"inputs":0,"x":270,"y":820,"wires":[["3b6d267456e57645"]]},{"id":"dab48f62303897b9","type":"subflow","name":"Repaint Button+","info":"","category":"","in":[{"x":80,"y":160,"wires":[{"id":"f42c0b2fc4ef01de"}]}],"out":[{"x":820,"y":260,"wires":[{"id":"5c74d059e31e2ce2","port":0},{"id":"8fbe5cb017582031","port":0}]}],"env":[],"meta":{},"color":"#DDAA99"},{"id":"3dc4de43ec19c069","type":"http request","z":"dab48f62303897b9","name":"Post JSON","method":"POST","ret":"txt","paytoqs":"body","url":"","tls":"","persist":true,"proxy":"","insecureHTTPParser":false,"authType":"","senderr":false,"headers":[{"keyType":"Content-Type","keyValue":"","valueType":"other","valueValue":"application/json"}],"x":550,"y":260,"wires":[[]]},{"id":"321fc9f9ab47b567","type":"http request","z":"dab48f62303897b9","name":"Login and set cookie","method":"POST","ret":"txt","paytoqs":"ignore","url":"","tls":"","persist":true,"proxy":"","insecureHTTPParser":true,"authType":"","senderr":false,"headers":[{"keyType":"Content-Type","keyValue":"","valueType":"other","valueValue":"application/json"}],"x":800,"y":180,"wires":[["06533975f7c0ba9f"]]},{"id":"8fbe5cb017582031","type":"function","z":"dab48f62303897b9","name":"Set headers","func":"msg.payload = {}\nmsg.payload['password']='d32uH*35q9WNA%';\nmsg.payload['email']='s.balkenende@gmail.com';\nmsg.payload['remember']=true;\nmsg.url = 'https://api.button.plus/account/login';\nmsg.posturl='http://192.168.1.81/configsave'\n//msg.posturl='https://api.button.plus/button/postbutton?id=139';\n\nmsg.headers = {};\nmsg.headers[\"Accept\"] = 'application/json';\nmsg.headers[\"Accept-Encoding\"] = 'gzip, deflate, br';\nmsg.headers[\"json\"] = true;\nreturn msg;\n","outputs":1,"timeout":0,"noerr":0,"initialize":"","finalize":"","libs":[],"x":550,"y":180,"wires":[["06533975f7c0ba9f"]],"icon":"font-awesome/fa-lock"},{"id":"06533975f7c0ba9f","type":"change","z":"dab48f62303897b9","name":"","rules":[{"t":"set","p":"payload","pt":"msg","to":"configJSON","tot":"msg"},{"t":"set","p":"url","pt":"msg","to":"posturl","tot":"msg"}],"action":"","property":"","from":"","to":"","reg":false,"x":340,"y":260,"wires":[["3dc4de43ec19c069"]]},{"id":"f42c0b2fc4ef01de","type":"function","z":"dab48f62303897b9","name":"Assemble json object","func":"var configJSON = {};\n\n// configJSON['info'] = '{ \"largedisplay\": 3, \"i2cs\": [],\"connectors\": [{\"id\": 3,\"type\": 2},{\"id\": 4,\"type\": 1}],\"sensors\": []}';\nconfigJSON['info'] = {\n        \"id\": \"btn_45a424\",\n    \"mac\": \"F4:12:FA:45:A4:24\",\n    \"ipaddress\": \"192.168.1.81\",\n    \"firmware\": \"1.07\",\n    \"largedisplay\": 0,\n    \"connectors\": [\n      { \"id\": 0, \"type\": 2},\n      { \"id\": 1, \"type\": 1},\n      { \"id\": 2, \"type\": 1},\n      { \"id\": 3, \"type\": 1 }\n    ],\n    \"sensors\": [\n      { \"sensorid\": 1, \"description\": \"Sensirion STS35 Temperature Sensor\" }\n    ]\n  }\n\n\n\nconfigJSON['core'] = {\n \"name\": \"btn_45a424\",\n    \"location\": \"Room 1\",\n    \"autobackup\": true,\n    \"brightnesslargedisplay\": 60,\n    \"brightnessminidisplay\": 50,\n    \"ledcolorfront\": 0,\n    \"ledcolorwall\": 0,\n    \"color\": 0\n  }\n  \nconfigJSON['mqttbuttons'] = global.get(\"mqttbuttons\",\"file\");\n// configJSON['mqttbuttons']=[];\nconfigJSON['mqttdisplays'] = global.get(\"displayitem_array\",\"file\");\nconfigJSON['mqttbrokers'] =  [\n    {\n            \"brokerid\": \"buttonplus\",\n            \"url\": \"mqtt://mqtt.button.plus\",\n            \"port\": 0,\n            \"wsport\": 0,\n            \"username\": \"\",\n            \"password\": \"\"\n        },{\n\n            \"brokerid\": \"ha\",\n            \"url\": \"mqtt://192.168.1.7\",\n            \"port\": 1883,\n            \"wsport\": 0,\n            \"username\": \"mqtt\",\n            \"password\": \"mqtt\"\n    }\n  ];\nconfigJSON['mqttsensors'] = [\n    {\n      \"sensorid\": 1,\n      \"topic\": {\n        \"brokerid\": \"buttonplus\",\n        \"topic\": \"button/btn_45a424/temperature\",\n        \"payload\": \"\",\n        \"eventtype\": 18\n      },\n      \"interval\": 10\n    }\n];\n\n\n\n// var info = '\"info\": { \"largedisplay\": 3, \"i2cs\": [],\"connectors\": [{\"id\": 3,\"type\": 2},{\"id\": 4,\"type\": 1}],\"sensors\": []}';\n// var core = '\"core\": {\"name\": \"demo3\",\"location\": \"Living Roommm\",\"color\": 0}';\n// var mqttbuttons = global.get(\"mqttbuttons\",\"file\");\n// var displayitemJSON = global.get(\"displayitemJSON\",\"file\");\n// var mqttbrokers = '\"mqttbrokers\": [{\"brokerid\": \"ha\",\"url\": \"ws://mqtt:mqtt@192.168.1.7\",\"port\": 1883,\"wsport\": 1884}]';\n// var mqttsensors = '\"mqttsensors\": []';\n\n// var configJSON = '{'+info+','+core+','+mqttbuttons+','+displayitemJSON+','+mqttbrokers+','+mqttsensors+'}';\nmsg.configJSON = configJSON;\nreturn msg;","outputs":1,"timeout":0,"noerr":0,"initialize":"","finalize":"","libs":[],"x":260,"y":180,"wires":[["5c74d059e31e2ce2","8fbe5cb017582031"]]},{"id":"6beaf8ac9c26aa14","type":"comment","z":"dab48f62303897b9","name":"Password in this node!","info":"","x":560,"y":140,"wires":[]},{"id":"075f059ef53236e9","type":"change","z":"dab48f62303897b9","name":"","rules":[{"t":"set","p":"cookies","pt":"msg","to":"responseCookies","tot":"msg","dc":true},{"t":"set","p":"payload","pt":"msg","to":"configJSON","tot":"msg"},{"t":"set","p":"url","pt":"msg","to":"posturl","tot":"msg"}],"action":"","property":"","from":"","to":"","reg":false,"x":340,"y":340,"wires":[[]]},{"id":"5c74d059e31e2ce2","type":"json","z":"dab48f62303897b9","d":true,"name":"","property":"configJSON","action":"","pretty":false,"x":370,"y":80,"wires":[["8fbe5cb017582031"]]},{"id":"184fc3689ec8cff8","type":"subflow","name":"Overdag","info":"","category":"","in":[{"x":50,"y":30,"wires":[{"id":"9f99a5ade7db557b"}]}],"out":[{"x":700,"y":80,"wires":[]},{"x":380,"y":180,"wires":[{"id":"f87693ac4927d90d","port":1}]},{"x":720,"y":180,"wires":[{"id":"d703c067babceafe","port":0}]}],"env":[],"meta":{},"color":"#DDAA99"},{"id":"9f99a5ade7db557b","type":"switch","z":"184fc3689ec8cff8","name":"","property":"action_type","propertyType":"msg","rules":[{"t":"eq","v":"click","vt":"str"},{"t":"eq","v":"release","vt":"str"},{"t":"else"}],"checkall":"true","repair":false,"outputs":3,"x":150,"y":80,"wires":[["f87693ac4927d90d"],[],["d703c067babceafe"]]},{"id":"f87693ac4927d90d","type":"switch","z":"184fc3689ec8cff8","name":"","property":"btn_click","propertyType":"msg","rules":[{"t":"eq","v":"0","vt":"str"},{"t":"eq","v":"1","vt":"str"},{"t":"eq","v":"2","vt":"str"},{"t":"eq","v":"3","vt":"str"},{"t":"eq","v":"4","vt":"str"},{"t":"eq","v":"5","vt":"str"},{"t":"eq","v":"6","vt":"str"},{"t":"eq","v":"7","vt":"str"}],"checkall":"true","repair":false,"outputs":8,"x":290,"y":280,"wires":[[],[],["33890701af0c2a56"],[],[],["8a4fbd720916f392"],["393a93f2e74b2ebf"],["b79c13e21bd5aa54"]]},{"id":"d703c067babceafe","type":"change","z":"184fc3689ec8cff8","name":"","rules":[{"t":"delete","p":"*","pt":"msg"},{"t":"set","p":"title","pt":"msg","to":"Weer","tot":"str"}],"action":"","property":"","from":"","to":"","reg":false,"x":560,"y":180,"wires":[[]]},{"id":"b79c13e21bd5aa54","type":"api-call-service","z":"184fc3689ec8cff8","name":"Ochtend aan","server":"c5f56a3a.f3f838","version":5,"debugenabled":false,"domain":"scene","service":"turn_on","areaId":["f003303ef40d4f74a22d0ac43952a198"],"deviceId":[],"entityId":["scene.ochtend_aan"],"data":"","dataType":"jsonata","mergeContext":"","mustacheAltTags":false,"outputProperties":[],"queue":"none","x":710,"y":440,"wires":[[]]},{"id":"393a93f2e74b2ebf","type":"api-call-service","z":"184fc3689ec8cff8","name":"","server":"c5f56a3a.f3f838","version":5,"debugenabled":false,"domain":"script","service":"woonkamer_lichten_uit","areaId":[],"deviceId":[],"entityId":[],"data":"","dataType":"jsonata","mergeContext":"","mustacheAltTags":false,"outputProperties":[],"queue":"none","x":480,"y":440,"wires":[[]]},{"id":"8a4fbd720916f392","type":"api-call-service","z":"184fc3689ec8cff8","name":"Woonkamer vol","server":"c5f56a3a.f3f838","version":5,"debugenabled":false,"domain":"scene","service":"turn_on","areaId":["f003303ef40d4f74a22d0ac43952a198"],"deviceId":[],"entityId":["scene.woonkamer_vol"],"data":"","dataType":"jsonata","mergeContext":"","mustacheAltTags":false,"outputProperties":[],"queue":"none","x":720,"y":380,"wires":[[]]},{"id":"33890701af0c2a56","type":"api-call-service","z":"184fc3689ec8cff8","name":"B+ clear prio","server":"c5f56a3a.f3f838","version":5,"debugenabled":false,"domain":"script","service":"buttonplus_notification_clear_prio","areaId":[],"deviceId":[],"entityId":[],"data":"","dataType":"jsonata","mergeContext":"","mustacheAltTags":false,"outputProperties":[],"queue":"none","x":470,"y":300,"wires":[[]]},{"id":"a9acc6cf693a7517","type":"subflow","name":"Muziek","info":"","category":"","in":[{"x":40,"y":80,"wires":[{"id":"515f7630507c6401"}]}],"out":[{"x":1080,"y":140,"wires":[]},{"x":620,"y":180,"wires":[{"id":"5456aa4b8eae2d3d","port":1}]},{"x":800,"y":80,"wires":[{"id":"515f7630507c6401","port":0}]}],"env":[],"meta":{},"color":"#DDAA99"},{"id":"515f7630507c6401","type":"switch","z":"a9acc6cf693a7517","name":"","property":"action_type","propertyType":"msg","rules":[{"t":"eq","v":"click","vt":"str"},{"t":"eq","v":"release","vt":"str"}],"checkall":"true","repair":false,"outputs":2,"x":210,"y":80,"wires":[["5456aa4b8eae2d3d"],[]]},{"id":"5456aa4b8eae2d3d","type":"switch","z":"a9acc6cf693a7517","name":"","property":"btn_click","propertyType":"msg","rules":[{"t":"eq","v":"0","vt":"str"},{"t":"eq","v":"1","vt":"str"},{"t":"eq","v":"2","vt":"str"},{"t":"eq","v":"3","vt":"str"},{"t":"eq","v":"4","vt":"str"},{"t":"eq","v":"5","vt":"str"},{"t":"eq","v":"6","vt":"str"},{"t":"eq","v":"7","vt":"str"}],"checkall":"true","repair":false,"outputs":8,"x":350,"y":280,"wires":[[],[],["49ed576b4d2491e9"],["633420e49a503b99"],["10e82ebb7eb88744"],["f65c5f016814f7b5"],["c5659767b659bbe2"],["03f382e637675111"]]},{"id":"03f382e637675111","type":"raumfeld-room-set-volume","z":"a9acc6cf693a7517","raumkernel":"56daf7a2.38988","roomName":"Woonkamer","volume":"5","relative":true,"unmute":true,"name":"","scope":"ROOM","x":800,"y":480,"wires":[]},{"id":"c5659767b659bbe2","type":"raumfeld-room-set-volume","z":"a9acc6cf693a7517","raumkernel":"56daf7a2.38988","roomName":"Woonkamer","volume":"-5","relative":true,"unmute":true,"name":"","scope":"ROOM","x":810,"y":440,"wires":[]},{"id":"47dfb30611ea3367","type":"raumfeld-room-action","z":"a9acc6cf693a7517","raumkernel":"56daf7a2.38988","roomName":"Woonkamer","action":"pause","name":"Pause","x":1110,"y":240,"wires":[]},{"id":"633420e49a503b99","type":"raumfeld-room-is-playing","z":"a9acc6cf693a7517","raumkernel":"56daf7a2.38988","roomName":"Woonkamer","name":"","x":650,"y":260,"wires":[["34c737621ba42fc1"]]},{"id":"34c737621ba42fc1","type":"switch","z":"a9acc6cf693a7517","name":"","property":"payload","propertyType":"msg","rules":[{"t":"true"},{"t":"false"}],"checkall":"true","repair":false,"outputs":2,"x":950,"y":260,"wires":[["47dfb30611ea3367"],["55874f7cc0c2e222"]]},{"id":"55874f7cc0c2e222","type":"raumfeld-room-action","z":"a9acc6cf693a7517","raumkernel":"56daf7a2.38988","roomName":"Woonkamer","action":"play","name":"Play","x":1110,"y":280,"wires":[]},{"id":"ecab2d96de5145a2","type":"api-call-service","z":"a9acc6cf693a7517","name":"","server":"c5f56a3a.f3f838","version":5,"debugenabled":false,"domain":"media_player","service":"media_play_pause","areaId":[],"deviceId":[],"entityId":["media_player.room_woonkamer"],"data":"","dataType":"jsonata","mergeContext":"","mustacheAltTags":false,"outputProperties":[],"queue":"none","x":810,"y":200,"wires":[[]]},{"id":"f65c5f016814f7b5","type":"api-call-service","z":"a9acc6cf693a7517","name":"","server":"c5f56a3a.f3f838","version":5,"debugenabled":false,"domain":"media_player","service":"media_next_track","areaId":[],"deviceId":[],"entityId":["media_player.room_woonkamer"],"data":"","dataType":"jsonata","mergeContext":"","mustacheAltTags":false,"outputProperties":[],"queue":"none","x":770,"y":380,"wires":[[]]},{"id":"10e82ebb7eb88744","type":"api-call-service","z":"a9acc6cf693a7517","name":"","server":"c5f56a3a.f3f838","version":5,"debugenabled":false,"domain":"media_player","service":"media_previous_track","areaId":[],"deviceId":[],"entityId":["media_player.room_woonkamer"],"data":"","dataType":"jsonata","mergeContext":"","mustacheAltTags":false,"outputProperties":[],"queue":"none","x":780,"y":340,"wires":[[]]},{"id":"49ed576b4d2491e9","type":"api-call-service","z":"a9acc6cf693a7517","name":"B+ clear prio","server":"c5f56a3a.f3f838","version":5,"debugenabled":false,"domain":"script","service":"buttonplus_notification_clear_prio","areaId":[],"deviceId":[],"entityId":[],"data":"","dataType":"jsonata","mergeContext":"","mustacheAltTags":false,"outputProperties":[],"queue":"none","x":750,"y":140,"wires":[[]]},{"id":"56daf7a2.38988","type":"raumfeld-raumkernel","raumfeldHost":"192.168.1.14"},{"id":"c08c93016134f590","type":"subflow","name":"Verlichting","info":"","category":"","in":[{"x":40,"y":80,"wires":[{"id":"172827c7fd06b0c5"}]}],"out":[{"x":740,"y":240,"wires":[]},{"x":560,"y":160,"wires":[{"id":"94321765ec8be854","port":1}]},{"x":740,"y":360,"wires":[]}],"env":[],"meta":{},"color":"#DDAA99"},{"id":"172827c7fd06b0c5","type":"switch","z":"c08c93016134f590","name":"","property":"action_type","propertyType":"msg","rules":[{"t":"eq","v":"click","vt":"str"},{"t":"eq","v":"release","vt":"str"}],"checkall":"true","repair":false,"outputs":2,"x":130,"y":80,"wires":[["94321765ec8be854"],["2e4d1bb70b601f69"]]},{"id":"94321765ec8be854","type":"switch","z":"c08c93016134f590","name":"Click","property":"btn_click","propertyType":"msg","rules":[{"t":"eq","v":"0","vt":"str"},{"t":"eq","v":"1","vt":"str"},{"t":"eq","v":"2","vt":"str"},{"t":"eq","v":"3","vt":"str"},{"t":"eq","v":"4","vt":"str"},{"t":"eq","v":"5","vt":"str"},{"t":"eq","v":"6","vt":"str"},{"t":"eq","v":"7","vt":"str"}],"checkall":"true","repair":false,"outputs":8,"x":350,"y":100,"wires":[[],[],["91cad3a9fd452134"],[],["50a15c3d3673eb88"],["31f9fb8fc846f7fe"],["85ae8312c44ede47"],["8d1918712ac9b072"]]},{"id":"2e4d1bb70b601f69","type":"switch","z":"c08c93016134f590","name":"Release","property":"btn_release","propertyType":"msg","rules":[{"t":"eq","v":"btn_1l","vt":"str"},{"t":"eq","v":"btn_1r","vt":"str"},{"t":"eq","v":"btn_2l","vt":"str"},{"t":"eq","v":"btn_2r","vt":"str"},{"t":"eq","v":"btn_3l","vt":"str"},{"t":"eq","v":"btn_3r","vt":"str"},{"t":"eq","v":"btn_4l","vt":"str"},{"t":"eq","v":"btn_4r","vt":"str"}],"checkall":"true","repair":false,"outputs":8,"x":160,"y":280,"wires":[[],[],[],[],[],[],[],[]]},{"id":"85ae8312c44ede47","type":"api-call-service","z":"c08c93016134f590","name":"","server":"c5f56a3a.f3f838","version":5,"debugenabled":false,"domain":"script","service":"woonkamer_lichten_uit","areaId":[],"deviceId":[],"entityId":[],"data":"","dataType":"jsonata","mergeContext":"","mustacheAltTags":false,"outputProperties":[],"queue":"none","x":540,"y":480,"wires":[[]]},{"id":"8d1918712ac9b072","type":"api-call-service","z":"c08c93016134f590","name":"Woonkamer vol","server":"c5f56a3a.f3f838","version":5,"debugenabled":false,"domain":"scene","service":"turn_on","areaId":["f003303ef40d4f74a22d0ac43952a198"],"deviceId":[],"entityId":["scene.woonkamer_vol"],"data":"","dataType":"jsonata","mergeContext":"","mustacheAltTags":false,"outputProperties":[],"queue":"none","x":780,"y":480,"wires":[[]]},{"id":"50a15c3d3673eb88","type":"api-call-service","z":"c08c93016134f590","name":"Woonkamer mid","server":"c5f56a3a.f3f838","version":5,"debugenabled":false,"domain":"scene","service":"turn_on","areaId":["f003303ef40d4f74a22d0ac43952a198"],"deviceId":[],"entityId":["scene.woonkamer_mid"],"data":"","dataType":"jsonata","mergeContext":"","mustacheAltTags":false,"outputProperties":[],"queue":"none","x":500,"y":420,"wires":[[]]},{"id":"31f9fb8fc846f7fe","type":"api-call-service","z":"c08c93016134f590","name":"Woonkamer mid","server":"c5f56a3a.f3f838","version":5,"debugenabled":false,"domain":"scene","service":"turn_on","areaId":["f003303ef40d4f74a22d0ac43952a198"],"deviceId":[],"entityId":["scene.woonkamer_dim"],"data":"","dataType":"jsonata","mergeContext":"","mustacheAltTags":false,"outputProperties":[],"queue":"none","x":780,"y":420,"wires":[[]]},{"id":"91cad3a9fd452134","type":"api-call-service","z":"c08c93016134f590","name":"B+ clear prio","server":"c5f56a3a.f3f838","version":5,"debugenabled":false,"domain":"script","service":"buttonplus_notification_clear_prio","areaId":[],"deviceId":[],"entityId":[],"data":"","dataType":"jsonata","mergeContext":"","mustacheAltTags":false,"outputProperties":[],"queue":"none","x":750,"y":120,"wires":[[]]},{"id":"c5f56a3a.f3f838","type":"server","name":"Home Assistant","version":5,"addon":true,"rejectUnauthorizedCerts":true,"ha_boolean":"y|yes|true|on|home|open","connectionDelay":true,"cacheJson":true,"heartbeat":false,"heartbeatInterval":"30","areaSelector":"friendlyName","deviceSelector":"friendlyName","entitySelector":"friendlyName","statusSeparator":"at: ","statusYear":"hidden","statusMonth":"short","statusDay":"numeric","statusHourCycle":"h23","statusTimeFormat":"h:m","enableGlobalContextStore":true},{"id":"67c52f5315a4cf88","type":"subflow","name":"Button+ Draw labels","info":"","category":"","in":[{"x":40,"y":80,"wires":[{"id":"5f2c23eec9b53338"},{"id":"9a88cc0e7dd08485"},{"id":"8bcda59f695193e6"},{"id":"95d86dcf1ca6d3b8"},{"id":"ab452d5340c50147"},{"id":"b66d378125aeb6c7"},{"id":"a974dcbe818ecf1f"},{"id":"89dad62b7431607c"}]}],"out":[{"x":720,"y":40,"wires":[{"id":"67c52f5315a4cf88","port":0}]}],"env":[],"meta":{},"color":"#DDAA99"},{"id":"5f2e2555f48c5092","type":"change","z":"67c52f5315a4cf88","name":"btn_1l","rules":[{"t":"set","p":"payload","pt":"msg","to":"btn_1l","tot":"msg"}],"action":"","property":"","from":"","to":"","reg":false,"x":430,"y":80,"wires":[["e2f6bb790b4a41ac"]]},{"id":"5f2c23eec9b53338","type":"function","z":"67c52f5315a4cf88","name":"concat 0","func":"var appendix = 0\nmsg.topic = msg.topic.concat(appendix).concat(\"/label\")\nreturn msg;","outputs":1,"timeout":"","noerr":0,"initialize":"","finalize":"","libs":[],"x":240,"y":80,"wires":[["5f2e2555f48c5092"]]},{"id":"e2f6bb790b4a41ac","type":"mqtt out","z":"67c52f5315a4cf88","name":"btn_1l","topic":"","qos":"0","retain":"true","respTopic":"","contentType":"","userProps":"","correl":"","expiry":"","broker":"e6dbd5fb3f32ec20","x":570,"y":80,"wires":[]},{"id":"f60b811e580343a3","type":"change","z":"67c52f5315a4cf88","name":"btn_1r","rules":[{"t":"set","p":"payload","pt":"msg","to":"btn_1r","tot":"msg"}],"action":"","property":"","from":"","to":"","reg":false,"x":430,"y":140,"wires":[["37f20ac3d41e4e5f"]]},{"id":"9a88cc0e7dd08485","type":"function","z":"67c52f5315a4cf88","name":"concat 1","func":"var appendix =1\nmsg.topic = msg.topic.concat(appendix).concat(\"/label\")\nreturn msg;","outputs":1,"timeout":"","noerr":0,"initialize":"","finalize":"","libs":[],"x":240,"y":140,"wires":[["f60b811e580343a3"]]},{"id":"37f20ac3d41e4e5f","type":"mqtt out","z":"67c52f5315a4cf88","name":"btn_1r","topic":"","qos":"0","retain":"true","respTopic":"","contentType":"","userProps":"","correl":"","expiry":"","broker":"e6dbd5fb3f32ec20","x":570,"y":140,"wires":[]},{"id":"fba14383722b8d20","type":"change","z":"67c52f5315a4cf88","name":"btn_2l","rules":[{"t":"set","p":"payload","pt":"msg","to":"btn_2l","tot":"msg"}],"action":"","property":"","from":"","to":"","reg":false,"x":430,"y":200,"wires":[["13d99c904a71a8f7"]]},{"id":"8bcda59f695193e6","type":"function","z":"67c52f5315a4cf88","name":"concat 2","func":"var appendix =2\nmsg.topic = msg.topic.concat(appendix).concat(\"/label\")\nreturn msg;","outputs":1,"timeout":"","noerr":0,"initialize":"","finalize":"","libs":[],"x":240,"y":200,"wires":[["fba14383722b8d20"]]},{"id":"13d99c904a71a8f7","type":"mqtt out","z":"67c52f5315a4cf88","name":"btn_2l","topic":"","qos":"0","retain":"true","respTopic":"","contentType":"","userProps":"","correl":"","expiry":"","broker":"e6dbd5fb3f32ec20","x":570,"y":200,"wires":[]},{"id":"1d214404600a2716","type":"change","z":"67c52f5315a4cf88","name":"btn_2r","rules":[{"t":"set","p":"payload","pt":"msg","to":"btn_2r","tot":"msg"}],"action":"","property":"","from":"","to":"","reg":false,"x":430,"y":260,"wires":[["c4d4cac4a0c95513"]]},{"id":"95d86dcf1ca6d3b8","type":"function","z":"67c52f5315a4cf88","name":"concat 3","func":"var appendix =3\nmsg.topic = msg.topic.concat(appendix).concat(\"/label\")\nreturn msg;","outputs":1,"timeout":"","noerr":0,"initialize":"","finalize":"","libs":[],"x":240,"y":260,"wires":[["1d214404600a2716"]]},{"id":"c4d4cac4a0c95513","type":"mqtt out","z":"67c52f5315a4cf88","name":"btn_2r","topic":"","qos":"0","retain":"true","respTopic":"","contentType":"","userProps":"","correl":"","expiry":"","broker":"e6dbd5fb3f32ec20","x":570,"y":260,"wires":[]},{"id":"6fd4d822b003a439","type":"change","z":"67c52f5315a4cf88","name":"btn_3l","rules":[{"t":"set","p":"payload","pt":"msg","to":"btn_3l","tot":"msg"}],"action":"","property":"","from":"","to":"","reg":false,"x":430,"y":320,"wires":[["b6aa721ab014d13c"]]},{"id":"ab452d5340c50147","type":"function","z":"67c52f5315a4cf88","name":"concat 4","func":"var appendix =4\nmsg.topic = msg.topic.concat(appendix).concat(\"/label\")\nreturn msg;","outputs":1,"timeout":"","noerr":0,"initialize":"","finalize":"","libs":[],"x":240,"y":320,"wires":[["6fd4d822b003a439"]]},{"id":"b6aa721ab014d13c","type":"mqtt out","z":"67c52f5315a4cf88","name":"btn_3l","topic":"","qos":"0","retain":"true","respTopic":"","contentType":"","userProps":"","correl":"","expiry":"","broker":"e6dbd5fb3f32ec20","x":570,"y":320,"wires":[]},{"id":"d585d41d4ea8233c","type":"change","z":"67c52f5315a4cf88","name":"btn_3r","rules":[{"t":"set","p":"payload","pt":"msg","to":"btn_3r","tot":"msg"}],"action":"","property":"","from":"","to":"","reg":false,"x":430,"y":380,"wires":[["36f1f1c1506a8ab1"]]},{"id":"b66d378125aeb6c7","type":"function","z":"67c52f5315a4cf88","name":"concat 5","func":"var appendix =5\nmsg.topic = msg.topic.concat(appendix).concat(\"/label\")\nreturn msg;","outputs":1,"timeout":"","noerr":0,"initialize":"","finalize":"","libs":[],"x":240,"y":380,"wires":[["d585d41d4ea8233c"]]},{"id":"36f1f1c1506a8ab1","type":"mqtt out","z":"67c52f5315a4cf88","name":"btn_3r","topic":"","qos":"0","retain":"true","respTopic":"","contentType":"","userProps":"","correl":"","expiry":"","broker":"e6dbd5fb3f32ec20","x":570,"y":380,"wires":[]},{"id":"83eb3b507d9828b4","type":"change","z":"67c52f5315a4cf88","name":"btn_4l","rules":[{"t":"set","p":"payload","pt":"msg","to":"btn_4l","tot":"msg"}],"action":"","property":"","from":"","to":"","reg":false,"x":430,"y":440,"wires":[["f0895adc62232206"]]},{"id":"a974dcbe818ecf1f","type":"function","z":"67c52f5315a4cf88","name":"concat 6","func":"var appendix =6\nmsg.topic = msg.topic.concat(appendix).concat(\"/label\")\nreturn msg;","outputs":1,"timeout":"","noerr":0,"initialize":"","finalize":"","libs":[],"x":240,"y":440,"wires":[["83eb3b507d9828b4"]]},{"id":"f0895adc62232206","type":"mqtt out","z":"67c52f5315a4cf88","name":"btn_4l","topic":"","qos":"0","retain":"true","respTopic":"","contentType":"","userProps":"","correl":"","expiry":"","broker":"e6dbd5fb3f32ec20","x":570,"y":440,"wires":[]},{"id":"6525eee16848cf18","type":"change","z":"67c52f5315a4cf88","name":"btn_4r","rules":[{"t":"set","p":"payload","pt":"msg","to":"btn_4r","tot":"msg"}],"action":"","property":"","from":"","to":"","reg":false,"x":430,"y":500,"wires":[["bd3b44a1bca57064"]]},{"id":"89dad62b7431607c","type":"function","z":"67c52f5315a4cf88","name":"concat 7","func":"var appendix =7\nmsg.topic = msg.topic.concat(appendix).concat(\"/label\")\nreturn msg;","outputs":1,"timeout":"","noerr":0,"initialize":"","finalize":"","libs":[],"x":240,"y":500,"wires":[["6525eee16848cf18"]]},{"id":"bd3b44a1bca57064","type":"mqtt out","z":"67c52f5315a4cf88","name":"btn_4r","topic":"","qos":"0","retain":"true","respTopic":"","contentType":"","userProps":"","correl":"","expiry":"","broker":"e6dbd5fb3f32ec20","x":570,"y":500,"wires":[]},{"id":"e6dbd5fb3f32ec20","type":"mqtt-broker","name":"","broker":"192.168.1.7","port":"1883","clientid":"","autoConnect":true,"usetls":false,"protocolVersion":"4","keepalive":"60","cleansession":true,"autoUnsubscribe":true,"birthTopic":"","birthQos":"0","birthPayload":"","birthMsg":{},"closeTopic":"","closeQos":"0","closePayload":"","closeMsg":{},"willTopic":"","willQos":"0","willPayload":"","willMsg":{},"userProps":"","sessionExpiry":""},{"id":"857c75046ddd42f1","type":"tab","label":"Button+ modes","disabled":false,"info":"","env":[]},{"id":"57d358e7d2fffd5f","type":"state-machine","z":"857c75046ddd42f1","name":"Modes","triggerProperty":"mode","triggerPropertyType":"msg","stateProperty":"mode","statePropertyType":"msg","initialDelay":"0","persistOnReload":true,"outputStateChangeOnly":false,"throwException":false,"states":["verlichting","muziek","overdag"],"transitions":[{"name":"change","from":"verlichting","to":"muziek"},{"name":"change","from":"muziek","to":"overdag"},{"name":"change","from":"overdag","to":"verlichting"},{"name":"verlichting","from":"*","to":"verlichting"},{"name":"overdag","from":"*","to":"overdag"},{"name":"muziek","from":"*","to":"muziek"}],"x":390,"y":280,"wires":[["e823fcbeff0a65e3","e02f33b0df9a8580"]]},{"id":"57b25e276386b4f4","type":"inject","z":"857c75046ddd42f1","name":"mode: change","props":[{"p":"mode","v":"change","vt":"str"}],"repeat":"","crontab":"","once":false,"onceDelay":0.1,"topic":"","x":150,"y":80,"wires":[["57d358e7d2fffd5f"]]},{"id":"e41717357199026b","type":"inject","z":"857c75046ddd42f1","name":"Mode: verlichting","props":[{"p":"mode","v":"verlichting","vt":"str"}],"repeat":"","crontab":"","once":false,"onceDelay":0.1,"topic":"","x":160,"y":120,"wires":[["57d358e7d2fffd5f"]]},{"id":"68a7d8e3f786943c","type":"inject","z":"857c75046ddd42f1","name":"Mode: muziek","props":[{"p":"mode","v":"muziek","vt":"str"}],"repeat":"","crontab":"","once":false,"onceDelay":0.1,"topic":"","x":150,"y":160,"wires":[["57d358e7d2fffd5f"]]},{"id":"9a45719dd75f9ebf","type":"inject","z":"857c75046ddd42f1","name":"Mode: overdag","props":[{"p":"mode","v":"overdag","vt":"str"}],"repeat":"","crontab":"","once":false,"onceDelay":0.1,"topic":"","x":160,"y":200,"wires":[["57d358e7d2fffd5f"]]},{"id":"d8fef9fadc2eb392","type":"switch","z":"857c75046ddd42f1","name":"","property":"mode","propertyType":"msg","rules":[{"t":"eq","v":"verlichting","vt":"str"},{"t":"eq","v":"muziek","vt":"str"},{"t":"eq","v":"overdag","vt":"str"}],"checkall":"true","repair":false,"outputs":3,"x":590,"y":120,"wires":[["77a19e23a13c5e5b"],["9b0d97cc94fffcb5"],["67316341f1c98e74"]]},{"id":"e823fcbeff0a65e3","type":"change","z":"857c75046ddd42f1","name":"","rules":[{"t":"set","p":"topic","pt":"msg","to":"buttonplus/wk1/button/","tot":"str"},{"t":"change","p":"mode","pt":"msg","from":"change","fromt":"str","to":"","tot":"str"}],"action":"","property":"","from":"","to":"","reg":false,"x":560,"y":280,"wires":[["d8fef9fadc2eb392"]]},{"id":"7ea61951e6e6ea89","type":"subflow:67c52f5315a4cf88","z":"857c75046ddd42f1","d":true,"name":"","x":1760,"y":180,"wires":[[]]},{"id":"1e0b563a39490715","type":"subflow:c08c93016134f590","z":"857c75046ddd42f1","name":"Verlichting","x":950,"y":420,"wires":[[],["1e056e9c9de1fcaa"],[]]},{"id":"1a3dc7c3c051b944","type":"subflow:a9acc6cf693a7517","z":"857c75046ddd42f1","name":"Muziek","x":940,"y":480,"wires":[[],["1e056e9c9de1fcaa"],[]]},{"id":"5a45bd34541ee319","type":"function","z":"857c75046ddd42f1","name":"mqttbuttons JSON","func":"context.mqttbuttonsarray = [];\n// var mqttbuttons_object = {};\n// var mqttbuttons_temp = {};\n\nvar topics = [];\n\nlet buttons = [0,1,2,3,4,5,6,7];\nlet labels = [msg.btn_1l,msg.btn_1r,msg.btn_2l,msg.btn_2r,msg.btn_3l,msg.btn_3r,msg.btn_4l,msg.btn_4r];\nlet toplabels = [msg.btn_toplabel_1l,msg.btn_toplabel_1r,msg.btn_toplabel_2l,msg.btn_toplabel_2r,msg.btn_toplabel_3l,msg.btn_toplabel_3r,msg.btn_toplabel_4l,msg.btn_toplabel_4r];\n\nfor (let i = 0; i < buttons.length; i++) {\n  var mqttbuttons_temp = {};\n  mqttbuttons_temp['id'] = i;\n  mqttbuttons_temp['label'] = labels[i];\n  mqttbuttons_temp['toplabel'] = toplabels[i];\n  mqttbuttons_temp['ledcolorfront'] = 0;\n  mqttbuttons_temp['ledcolorwall'] = 0;\n  // mqttbuttons_temp['topics'] = [\n  if (i==0 || i==1){\n    topics = [\n    { \"brokerid\": \"ha\",\n      \"topic\": \"buttonplus/wk1/button/\" + buttons[i] + \"/state\",\n      \"payload\": buttons[i].toString(),\n      \"eventtype\": 0 },\n    { \"brokerid\": \"ha\",\n      \"topic\": \"buttonplus/wk1/button/\" + buttons[i] + \"/longpress\",\n      \"payload\": buttons[i].toString(),\n      \"eventtype\": 1 }]\n  } else {\n  topics = [\n    { \"brokerid\": \"ha\",\n      \"topic\": \"buttonplus/wk1/button/\" + buttons[i] + \"/state\",\n      \"payload\": buttons[i].toString(),\n      \"eventtype\": 0 }\n    ,{ \"brokerid\": \"ha\",\n      \"topic\": \"buttonplus/wk1/button/\" + buttons[i] + \"/longpress\",\n      \"payload\": buttons[i].toString(),\n      \"eventtype\": 1 }\n    // // { \"brokerid\": \"ha\",\n    // //   \"topic\": \"buttonplus/wk1/button/\" + buttons[i] + \"/release\",\n    // //   \"payload\": buttons[i].toString(),\n    // //   \"eventtype\": 2 },\n    // ,{ \"brokerid\": \"ha\",\n    //   \"topic\": \"buttonplus/wk1/button/\" + buttons[i] + \"/ledblue\",\n    //   \"payload\": \"on\",\n    //   \"eventtype\": 8 }\n    // ,{ \"brokerid\": \"ha\",\n    //   \"topic\": \"buttonplus/wk1/button/\" + buttons[i] + \"/ledred\",\n    //   \"payload\": \"on\",\n    //   \"eventtype\": 9 }\n    // ,{ \"brokerid\": \"ha\",\n    //   \"topic\": \"buttonplus/wk1/button/\" + buttons[i] + \"/ledgreen\",\n    //   \"payload\": \"on\",\n    //   \"eventtype\": 10 }\n    ,{ \"brokerid\": \"ha\",\n      \"topic\": \"buttonplus/wk1/button/\" + buttons[i] + \"/label\",\n      // \"payload\": \"\",\n      \"eventtype\": 11}\n    ,{\n      \"brokerid\": \"ha\",\n      \"topic\": \"buttonplus/wk1/button/\" + buttons[i] + \"/toplabel\",\n      // \"payload\": \"\",\n      \"eventtype\": 12 }  \n    \n    // ,{ \"brokerid\": \"ha\",\n    //   \"topic\": \"buttonplus/wk1/button/\" + buttons[i] + \"/led\",\n    //   \"payload\": \"on\",\n    //   \"eventtype\": 14 }\n    \n    , {\n      \"brokerid\": \"ha\",\n      \"topic\": \"buttonplus/wk1/button/\" + buttons[i] + \"/rgbled\",\n      \"payload\": \"0\",\n      // .toString()\n      \"eventtype\": 13\n    }  \n    ]\n  }  \n    // topics = [];\n  \n    // context.topics.push(ledgreen);\n    mqttbuttons_temp['topics'] = topics;\n  context.mqttbuttonsarray.push(mqttbuttons_temp);\n}\n\n// mqttbuttons_object['mqttbuttons']=context.mqttbuttonsarray;\nglobal.set(\"mqttbuttons\",context.mqttbuttonsarray,\"file\");\nmsg.mqttbuttons = context.mqttbuttonsarray;\n\nreturn msg;","outputs":1,"timeout":0,"noerr":0,"initialize":"","finalize":"","libs":[],"x":1350,"y":60,"wires":[["f0f0dc5993cf91e1"]]},{"id":"8c681f70135aae74","type":"function","z":"857c75046ddd42f1","name":"displayitem objects","func":"// This function prepares a single display item based on input\n// it is saved in flow variable with key msg.displayitem (a number)\n\n// retrieve any saved display items\nvar displayitemJSONobjects=flow.get('displayitemJSONobjects',\"file\") || {};\nif (displayitemJSONobjects===undefined)//test exists\n{\n  displayitemJSONobjects = {};\n}\nif (msg.delete != true || msg.displayitem != \"undefined\"){\n    \n    // setting of the displayitem key\n    if (typeof msg.displayitem === \"undefined\") {\n        var displayitem = context.get(+displayitem+\".displayitem\", \"file\");\n    } else {\n        var displayitem = msg.displayitem;\n        context.set(+displayitem+\".displayitem\", displayitem, \"file\");\n    }\n\n    // var x = context.get(+displayitem+\".x\",\"file\");\n    if (typeof msg.x === \"undefined\"){\n        var x = context.get(+displayitem+\".x\",\"file\");\n    } else {\n        var x = msg.x;\n        context.set(+displayitem+\".x\", x, \"file\");\n    }\n    if (typeof msg.y === \"undefined\"){\n        var y = context.get(+displayitem+\".y\",\"file\");\n    } else {\n        var y = msg.y;\n        context.set(+displayitem+\".y\", y, \"file\");\n    }\n    if (typeof msg.fontsize === \"undefined\"){\n        var fontsize = context.get(+displayitem+\".fontsize\",\"file\");\n    } else {\n        var fontsize = msg.fontsize;\n        context.set(+displayitem+\".fontsize\", fontsize, \"file\");\n    }\n    if (typeof msg.align === \"undefined\"){\n        var align = context.get(+displayitem+\".align\",\"file\");\n    } else {\n        var align = msg.align;\n        context.set(+displayitem+\".align\", align, \"file\");\n    }\n    if (typeof msg.width === \"undefined\"){\n        var width = context.get(+displayitem+\".width\",\"file\");\n    } else {\n        var width = msg.width;\n        context.set(+displayitem+\".width\", width, \"file\");\n    }\n    if (typeof msg.label === \"undefined\"){\n        var label = context.get(+displayitem+\".label\",\"file\");\n    } else {\n        var label = msg.label;\n        context.set(+displayitem+\".label\", label, \"file\");\n    }\n    if (typeof msg.unit === \"undefined\"){\n        var unit = context.get(+displayitem+\".unit\",\"file\");\n    } else {\n        var unit = msg.unit;\n        context.set(+displayitem+\".unit\", unit, \"file\");\n    }\n    if (typeof msg.round === \"undefined\"){\n        var round = context.get(+displayitem+\".round\",\"file\");\n    } else {\n        var round = msg.round;\n        context.set(+displayitem+\".round\", round, \"file\");\n    }\n\n    var displayitemJSON_temp = {} ;\n    displayitemJSON_temp['x'] = x;\n    displayitemJSON_temp['y'] = y;\n    displayitemJSON_temp['fontsize'] = fontsize;\n    displayitemJSON_temp['align'] = align;\n    displayitemJSON_temp['width'] = width;\n    displayitemJSON_temp['label'] = label;\n    displayitemJSON_temp['unit'] = unit;\n    displayitemJSON_temp['round'] = round;\n    \n    displayitemJSON_temp['topics'] = [{ \"brokerid\": \"ha\",\n            \"topic\": \"buttonplus/wk1/display/\" + displayitem + \"/value\",\n            \"eventtype\": 15},{\n            \"brokerid\": \"ha\", \"topic\": \"buttonplus/wk1/display/\" + displayitem + \"/label\",\n            \"eventtype\": 16},{\n            \"brokerid\": \"ha\",\"topic\": \"buttonplus/wk1/display/\" + displayitem + \"/uom\",\n            \"eventtype\": 17}\n        ]\n    \n    displayitemJSONobjects[displayitem]=displayitemJSON_temp;\n}\n\nif (msg.delete == true && msg.displayitem != \"undefined\") {\n    delete displayitemJSONobjects[displayitem];\n}\n\ncontext.displayitem_array = [];\n\n\nlet keys=Object.keys(displayitemJSONobjects); //return array of keys\nfor (let i=0;i<keys.length;i++)\n { \nlet key=keys[i];\n    context.displayitem_array.push(displayitemJSONobjects[key]);\n }\n\n\n\nmsg.error = context.displayitem_array;\nmsg.payload = displayitemJSONobjects;\nflow.set(\"displayitemJSONobjects\",displayitemJSONobjects,\"file\");\nglobal.set(\"displayitem_array\",context.displayitem_array,\"file\");\nreturn msg;","outputs":1,"timeout":0,"noerr":0,"initialize":"","finalize":"","libs":[],"x":570,"y":700,"wires":[["e4a618421774c9ba","1458669cfb1acb9f"]]},{"id":"1458669cfb1acb9f","type":"debug","z":"857c75046ddd42f1","name":"debug 15","active":false,"tosidebar":true,"console":false,"tostatus":false,"complete":"payload","targetType":"msg","statusVal":"","statusType":"auto","x":1120,"y":780,"wires":[]},{"id":"44525b84400bead0","type":"inject","z":"857c75046ddd42f1","name":"displayitem 1","props":[{"p":"displayitem","v":"1","vt":"num"},{"p":"x","v":"0","vt":"num"},{"p":"y","v":"0","vt":"num"},{"p":"fontsize","v":"3","vt":"num"},{"p":"width","v":"25","vt":"num"},{"p":"label","v":"Dit is een label","vt":"str"},{"p":"unit","v":"°C","vt":"str"},{"p":"round","v":"1","vt":"num"},{"p":"align","v":"8","vt":"str"}],"repeat":"","crontab":"","once":false,"onceDelay":0.1,"topic":"","x":210,"y":520,"wires":[["8c681f70135aae74"]]},{"id":"4cbb20bd42974492","type":"inject","z":"857c75046ddd42f1","name":"displayitem2","props":[{"p":"displayitem","v":"2","vt":"num"},{"p":"x","v":"36","vt":"num"},{"p":"y","v":"0","vt":"num"},{"p":"fontsize","v":"3","vt":"num"},{"p":"width","v":"25","vt":"num"},{"p":"label","v":"Dit is een label2","vt":"str"},{"p":"unit","v":"°C","vt":"str"},{"p":"round","v":"0","vt":"num"},{"p":"align","v":"0","vt":"str"}],"repeat":"","crontab":"","once":false,"onceDelay":0.1,"topic":"","x":210,"y":620,"wires":[["8c681f70135aae74"]]},{"id":"0a19de580238406c","type":"inject","z":"857c75046ddd42f1","name":"displayitem4","props":[{"p":"displayitem","v":"4","vt":"num"},{"p":"x","v":"0","vt":"num"},{"p":"y","v":"20","vt":"num"},{"p":"fontsize","v":"1","vt":"num"},{"p":"width","v":"100","vt":"num"},{"p":"label","v":"Dit is een label2","vt":"str"},{"p":"unit","v":"°CC","vt":"str"},{"p":"round","v":"0","vt":"num"}],"repeat":"","crontab":"","once":false,"onceDelay":0.1,"topic":"","x":210,"y":720,"wires":[["8c681f70135aae74"]]},{"id":"544a2598527c044e","type":"inject","z":"857c75046ddd42f1","name":"delete1","props":[{"p":"delete","v":"true","vt":"bool"},{"p":"displayitem","v":"1","vt":"num"}],"repeat":"","crontab":"","once":false,"onceDelay":0.1,"topic":"","x":190,"y":560,"wires":[["8c681f70135aae74"]]},{"id":"bf43f751ddeae1a3","type":"inject","z":"857c75046ddd42f1","name":"delete2","props":[{"p":"delete","v":"true","vt":"bool"},{"p":"displayitem","v":"2","vt":"num"}],"repeat":"","crontab":"","once":false,"onceDelay":0.1,"topic":"","x":190,"y":660,"wires":[["8c681f70135aae74"]]},{"id":"a3728458ce4099ba","type":"inject","z":"857c75046ddd42f1","name":"delete4","props":[{"p":"delete","v":"true","vt":"bool"},{"p":"displayitem","v":"4","vt":"num"}],"repeat":"","crontab":"","once":false,"onceDelay":0.1,"topic":"","x":190,"y":760,"wires":[["8c681f70135aae74"]]},{"id":"448d40eac0f05ff7","type":"debug","z":"857c75046ddd42f1","name":"debug 16","active":true,"tosidebar":true,"console":false,"tostatus":false,"complete":"true","targetType":"full","statusVal":"","statusType":"auto","x":800,"y":300,"wires":[]},{"id":"1e056e9c9de1fcaa","type":"change","z":"857c75046ddd42f1","name":"","rules":[{"t":"set","p":"mode","pt":"msg","to":"change","tot":"str"},{"t":"set","p":"btn_click","pt":"msg","to":"","tot":"str"},{"t":"set","p":"action_type","pt":"msg","to":"","tot":"str"}],"action":"","property":"","from":"","to":"","reg":false,"x":1220,"y":480,"wires":[["2b9a2dd729a6e3f4"]]},{"id":"8f36fd5bd85d99b8","type":"subflow:184fc3689ec8cff8","z":"857c75046ddd42f1","name":"Overdag","x":940,"y":540,"wires":[[],["1e056e9c9de1fcaa"],[]]},{"id":"1d0cd71cc6172e52","type":"inject","z":"857c75046ddd42f1","name":"displayitem5","props":[{"p":"displayitem","v":"5","vt":"num"},{"p":"x","v":"70","vt":"num"},{"p":"y","v":"77","vt":"num"},{"p":"fontsize","v":"1","vt":"num"},{"p":"width","v":"30","vt":"num"},{"p":"label","v":"Menu","vt":"str"},{"p":"unit","v":"","vt":"str"},{"p":"round","v":"0","vt":"num"},{"p":"align","v":"0","vt":"str"}],"repeat":"","crontab":"","once":false,"onceDelay":0.1,"topic":"","x":210,"y":860,"wires":[["8c681f70135aae74"]]},{"id":"4dc7272534e13785","type":"inject","z":"857c75046ddd42f1","name":"delete5","props":[{"p":"delete","v":"true","vt":"bool"},{"p":"displayitem","v":"5","vt":"num"}],"repeat":"","crontab":"","once":false,"onceDelay":0.1,"topic":"","x":190,"y":900,"wires":[["8c681f70135aae74"]]},{"id":"e3d1060b1d5ac570","type":"comment","z":"857c75046ddd42f1","name":"5 = Next Menu","info":"","x":160,"y":820,"wires":[]},{"id":"e4a618421774c9ba","type":"subflow:dab48f62303897b9","z":"857c75046ddd42f1","name":"Repaint Button+","x":840,"y":700,"wires":[[]]},{"id":"f0f0dc5993cf91e1","type":"subflow:dab48f62303897b9","z":"857c75046ddd42f1","name":"Repaint Button+","x":1560,"y":60,"wires":[[]]},{"id":"e02f33b0df9a8580","type":"state-machine","z":"857c75046ddd42f1","name":"Modes","triggerProperty":"mode","triggerPropertyType":"msg","stateProperty":"mode","statePropertyType":"msg","initialDelay":"0","persistOnReload":true,"outputStateChangeOnly":false,"throwException":false,"states":["verlichting","overdag","muziek"],"transitions":[{"name":"verlichting","from":"*","to":"verlichting"},{"name":"overdag","from":"*","to":"overdag"},{"name":"muziek","from":"*","to":"muziek"}],"x":530,"y":460,"wires":[["9ee48b9bd254fe81"]]},{"id":"9ee48b9bd254fe81","type":"switch","z":"857c75046ddd42f1","name":"","property":"mode","propertyType":"msg","rules":[{"t":"eq","v":"verlichting","vt":"str"},{"t":"eq","v":"muziek","vt":"str"},{"t":"eq","v":"overdag","vt":"str"}],"checkall":"true","repair":false,"outputs":3,"x":750,"y":460,"wires":[["1e0b563a39490715"],["1a3dc7c3c051b944"],["8f36fd5bd85d99b8"]]},{"id":"9b0d97cc94fffcb5","type":"change","z":"857c75046ddd42f1","name":"draw Muziek label","rules":[{"t":"set","p":"label.0","pt":"msg","to":"Slaapstand","tot":"str"},{"t":"set","p":"label.1","pt":"msg","to":"Avond","tot":"str"},{"t":"set","p":"label.2","pt":"msg","to":"","tot":"str"},{"t":"set","p":"label.3","pt":"msg","to":"Play/Pause","tot":"str"},{"t":"set","p":"label.4","pt":"msg","to":"Previous","tot":"str"},{"t":"set","p":"label.5","pt":"msg","to":"Next","tot":"str"},{"t":"set","p":"label.6","pt":"msg","to":"-","tot":"str"},{"t":"set","p":"label.7","pt":"msg","to":"+","tot":"str"},{"t":"set","p":"toplabel.0","pt":"msg","to":" ","tot":"str"},{"t":"set","p":"toplabel.1","pt":"msg","to":"1","tot":"str"},{"t":"set","p":"toplabel.2","pt":"msg","to":"","tot":"str"},{"t":"set","p":"toplabel.3","pt":"msg","to":"","tot":"str"},{"t":"set","p":"toplabel.4","pt":"msg","to":"","tot":"str"},{"t":"set","p":"toplabel.5","pt":"msg","to":"","tot":"str"},{"t":"set","p":"toplabel.6","pt":"msg","to":"Volume","tot":"str"},{"t":"set","p":"toplabel.7","pt":"msg","to":"Volume","tot":"str"},{"t":"set","p":"title","pt":"msg","to":"Muziek","tot":"str"},{"t":"set","p":"ledrgb.0","pt":"msg","to":"0","tot":"num"},{"t":"set","p":"ledrgb.1","pt":"msg","to":"0","tot":"num"},{"t":"set","p":"ledrgb.2","pt":"msg","to":"0","tot":"num"},{"t":"set","p":"ledrgb.3","pt":"msg","to":"0","tot":"num"},{"t":"set","p":"ledrgb.4","pt":"msg","to":"0","tot":"num"},{"t":"set","p":"ledrgb.5","pt":"msg","to":"0","tot":"num"},{"t":"set","p":"ledrgb.6","pt":"msg","to":"0","tot":"num"},{"t":"set","p":"ledrgb.7","pt":"msg","to":"0","tot":"num"}],"action":"","property":"","from":"","to":"","reg":false,"x":810,"y":120,"wires":[["60a9b14f03b54ea6","607a55b1c7f5a0c5","258311fdb53399c1","6cab083c6367c424"]]},{"id":"42a05c85022bac3c","type":"subflow:6f1d57e2cbc01e62","z":"857c75046ddd42f1","name":"Button clicks","x":210,"y":420,"wires":[["e02f33b0df9a8580"]]},{"id":"2b9a2dd729a6e3f4","type":"link out","z":"857c75046ddd42f1","name":"Link change menu","mode":"link","links":["2b2cbc0cc969325f"],"x":1415,"y":480,"wires":[]},{"id":"2b2cbc0cc969325f","type":"link in","z":"857c75046ddd42f1","name":"Link change menu","links":["2b9a2dd729a6e3f4"],"x":275,"y":80,"wires":[["57d358e7d2fffd5f"]]},{"id":"14b36c35e40cb1c5","type":"debug","z":"857c75046ddd42f1","name":"debug 18","active":false,"tosidebar":true,"console":false,"tostatus":false,"complete":"true","targetType":"full","statusVal":"","statusType":"auto","x":1760,"y":60,"wires":[]},{"id":"8ea2439299a7ead9","type":"inject","z":"857c75046ddd42f1","name":"","props":[{"p":"r","v":"184","vt":"num"},{"p":"g","v":"184","vt":"num"},{"p":"b","v":"184","vt":"num"}],"repeat":"","crontab":"","once":false,"onceDelay":0.1,"topic":"","x":170,"y":1000,"wires":[["6edfb42c4eebf3c2"]]},{"id":"6edfb42c4eebf3c2","type":"function","z":"857c75046ddd42f1","name":"function 2","func":"var r = msg.r;\nvar g = msg.g;\nvar b = msg.b;\nfunction componentToHex(c) {\n  var hex = c.toString(16);\n  return hex.length == 1 ? \"0\" + hex : hex;\n}\n\nfunction rgbToHex(r, g, b) {\n  return componentToHex(r) + componentToHex(g) + componentToHex(b);\n  // return \"#\" + componentToHex(r) + componentToHex(g) + componentToHex(b);\n}\n\n// yourNumber = parseInt(hexString, 16);\n\nmsg.payload = parseInt(rgbToHex(r, g, b),16); // #0033ff\nreturn msg;","outputs":1,"timeout":0,"noerr":0,"initialize":"","finalize":"","libs":[],"x":380,"y":1000,"wires":[[]]},{"id":"3c277dd05877a7cf","type":"debug","z":"857c75046ddd42f1","name":"debug 19","active":true,"tosidebar":true,"console":false,"tostatus":false,"complete":"true","targetType":"full","statusVal":"","statusType":"auto","x":680,"y":1380,"wires":[]},{"id":"739fbb1589576f28","type":"inject","z":"857c75046ddd42f1","name":"displayitem3","props":[{"p":"displayitem","v":"3","vt":"num"},{"p":"x","v":"0","vt":"num"},{"p":"y","v":"31","vt":"num"},{"p":"fontsize","v":"2","vt":"num"},{"p":"width","v":"100","vt":"num"},{"p":"label","v":"","vt":"str"},{"p":"unit","v":"","vt":"str"},{"p":"round","v":"0","vt":"num"},{"p":"align","v":"0","vt":"str"}],"repeat":"","crontab":"","once":false,"onceDelay":0.1,"topic":"","x":510,"y":560,"wires":[["8c681f70135aae74"]]},{"id":"dd6600881249f28f","type":"inject","z":"857c75046ddd42f1","name":"delete3","props":[{"p":"delete","v":"true","vt":"bool"},{"p":"displayitem","v":"3","vt":"num"}],"repeat":"","crontab":"","once":false,"onceDelay":0.1,"topic":"","x":490,"y":600,"wires":[["8c681f70135aae74"]]},{"id":"7d22e38f463359d1","type":"debug","z":"857c75046ddd42f1","name":"debug 22","active":false,"tosidebar":true,"console":false,"tostatus":false,"complete":"true","targetType":"full","statusVal":"","statusType":"auto","x":1180,"y":380,"wires":[]},{"id":"601b4d3e557856b7","type":"inject","z":"857c75046ddd42f1","name":"repaint","props":[{"p":"mode","v":"muziek","vt":"str"},{"p":"repaint","v":"true","vt":"bool"}],"repeat":"","crontab":"","once":false,"onceDelay":0.1,"topic":"","x":110,"y":300,"wires":[["57d358e7d2fffd5f"]]},{"id":"60a9b14f03b54ea6","type":"switch","z":"857c75046ddd42f1","name":"repaint?","property":"repaint","propertyType":"msg","rules":[{"t":"true"},{"t":"else"}],"checkall":"true","repair":false,"outputs":2,"x":1140,"y":60,"wires":[["5a45bd34541ee319"],[]]},{"id":"5dc2db486022be82","type":"gate","z":"857c75046ddd42f1","name":"","controlTopic":"control","defaultState":"open","openCmd":"open","closeCmd":"close","toggleCmd":"toggle","defaultCmd":"default","statusCmd":"status","persist":false,"storeName":"memoryOnly","x":1990,"y":380,"wires":[["e30816331f38f9df","a7acfad3a98d31e9"]]},{"id":"e30816331f38f9df","type":"debug","z":"857c75046ddd42f1","name":"debug 23","active":false,"tosidebar":true,"console":false,"tostatus":false,"complete":"true","targetType":"full","statusVal":"","statusType":"auto","x":2200,"y":380,"wires":[]},{"id":"017754c6130107f7","type":"change","z":"857c75046ddd42f1","name":"Overdag open","rules":[{"t":"set","p":"payload","pt":"msg","to":"open","tot":"str"},{"t":"set","p":"topic","pt":"msg","to":"control","tot":"str"}],"action":"","property":"","from":"","to":"","reg":false,"x":1800,"y":320,"wires":[["5dc2db486022be82"]]},{"id":"607a55b1c7f5a0c5","type":"change","z":"857c75046ddd42f1","name":"Overdag close","rules":[{"t":"set","p":"payload","pt":"msg","to":"close","tot":"str"},{"t":"set","p":"topic","pt":"msg","to":"control","tot":"str"}],"action":"","property":"","from":"","to":"","reg":false,"x":1800,"y":280,"wires":[["5dc2db486022be82"]]},{"id":"1d74f413fc65de04","type":"delay","z":"857c75046ddd42f1","name":"","pauseType":"delay","timeout":"1","timeoutUnits":"seconds","rate":"1","nbRateUnits":"1","rateUnits":"second","randomFirst":"1","randomLast":"5","randomUnits":"seconds","drop":false,"allowrate":false,"outputs":1,"x":1820,"y":360,"wires":[["5dc2db486022be82"]]},{"id":"5434edf396d3fb0c","type":"subflow:fd2bb19b59cf119e","z":"857c75046ddd42f1","name":"","x":2410,"y":240,"wires":[]},{"id":"31581b9ca2133cbf","type":"debug","z":"857c75046ddd42f1","name":"debug 24","active":true,"tosidebar":true,"console":false,"tostatus":false,"complete":"true","targetType":"full","statusVal":"","statusType":"auto","x":2340,"y":340,"wires":[]},{"id":"a7acfad3a98d31e9","type":"change","z":"857c75046ddd42f1","name":"","rules":[{"t":"set","p":"label","pt":"msg","to":"Regen komende 15 min","tot":"str"},{"t":"set","p":"payload","pt":"msg","to":"$number(payload)","tot":"jsonata"},{"t":"set","p":"uom","pt":"msg","to":"","tot":"str"}],"action":"","property":"","from":"","to":"","reg":false,"x":2020,"y":220,"wires":[["89cc41edcdef8c73"]]},{"id":"3b7f0464315df9e0","type":"http request","z":"857c75046ddd42f1","name":"Post JSON","method":"POST","ret":"txt","paytoqs":"body","url":"","tls":"","persist":true,"proxy":"","insecureHTTPParser":false,"authType":"","senderr":false,"headers":[{"keyType":"Content-Type","keyValue":"","valueType":"other","valueValue":"application/json"}],"x":670,"y":1280,"wires":[[]]},{"id":"45ab88b641cd1844","type":"change","z":"857c75046ddd42f1","name":"","rules":[{"t":"set","p":"url","pt":"msg","to":"http://192.168.1.81/configsave","tot":"str"}],"action":"","property":"","from":"","to":"","reg":false,"x":490,"y":1280,"wires":[["3b7f0464315df9e0"]]},{"id":"868b82c96c710c61","type":"function","z":"857c75046ddd42f1","name":"Assemble json object","func":"// default config\nvar configJSON = '{\"info\":{\"id\":\"btn_45a424\",\"mac\":\"F4:12:FA:45:A4:24\",\"ipaddress\":\"192.168.1.81\",\"firmware\":\"1.07\",\"largedisplay\":0,\"connectors\":[{\"id\":0,\"type\":2},{\"id\":1,\"type\":1},{\"id\":2,\"type\":1},{\"id\":3,\"type\":1}],\"sensors\":[{\"sensorid\":1,\"description\":\"Sensirion STS35 Temperature Sensor\"}]},\"core\":{\"name\":\"btn_45a424\",\"location\":\"Room 1\",\"autobackup\":true,\"brightnesslargedisplay\":\"61\",\"brightnessminidisplay\":50,\"ledcolorfront\":0,\"ledcolorwall\":0,\"color\":0},\"mqttbuttons\":[{\"id\":0,\"label\":\"0\",\"toplabel\":\" 0\",\"ledcolorfront\":0,\"ledcolorwall\":0,\"topics\":[{\"brokerid\":\"ha\",\"topic\":\"buttonplus/wk1/button/0/state\",\"payload\":\"0\",\"eventtype\":0},{\"brokerid\":\"ha\",\"topic\":\"buttonplus/wk1/button/0/longpress\",\"payload\":\"0\",\"eventtype\":1}]},{\"id\":1,\"label\":\"1\",\"toplabel\":\"1\",\"ledcolorfront\":0,\"ledcolorwall\":0,\"topics\":[{\"brokerid\":\"ha\",\"topic\":\"buttonplus/wk1/button/1/state\",\"payload\":\"1\",\"eventtype\":0},{\"brokerid\":\"ha\",\"topic\":\"buttonplus/wk1/button/1/longpress\",\"payload\":\"1\",\"eventtype\":1}]},{\"id\":2,\"label\":\"1\",\"toplabel\":\"2\",\"ledcolorfront\":0,\"ledcolorwall\":0,\"topics\":[{\"brokerid\":\"ha\",\"topic\":\"buttonplus/wk1/button/2/state\",\"payload\":\"2\",\"eventtype\":0},{\"brokerid\":\"ha\",\"topic\":\"buttonplus/wk1/button/2/longpress\",\"payload\":\"2\",\"eventtype\":1},{\"brokerid\":\"ha\",\"topic\":\"buttonplus/wk1/button/2/label\",\"payload\":\"\",\"eventtype\":11},{\"brokerid\":\"ha\",\"topic\":\"buttonplus/wk1/button/2/toplabel\",\"payload\":\"\",\"eventtype\":12},{\"brokerid\":\"ha\",\"topic\":\"buttonplus/wk1/button/2/ledrgb\",\"payload\":\"\",\"eventtype\":13},{\"brokerid\":\"ha\",\"topic\":\"buttonplus/wk1/button/2/led\",\"payload\":\"on\",\"eventtype\":14}]},{\"id\":3,\"label\":\"Play/Pause\",\"toplabel\":\"3\",\"ledcolorfront\":0,\"ledcolorwall\":0,\"topics\":[{\"brokerid\":\"ha\",\"topic\":\"buttonplus/wk1/button/3/state\",\"payload\":\"3\",\"eventtype\":0},{\"brokerid\":\"ha\",\"topic\":\"buttonplus/wk1/button/3/longpress\",\"payload\":\"3\",\"eventtype\":1},{\"brokerid\":\"ha\",\"topic\":\"buttonplus/wk1/button/3/label\",\"payload\":\"\",\"eventtype\":11},{\"brokerid\":\"ha\",\"topic\":\"buttonplus/wk1/button/3/toplabel\",\"payload\":\"\",\"eventtype\":12},{\"brokerid\":\"ha\",\"topic\":\"buttonplus/wk1/button/3/ledrgb\",\"payload\":\"\",\"eventtype\":13},{\"brokerid\":\"ha\",\"topic\":\"buttonplus/wk1/button/3/led\",\"payload\":\"on\",\"eventtype\":14}]},{\"id\":4,\"label\":\"Previous\",\"toplabel\":\"4\",\"ledcolorfront\":0,\"ledcolorwall\":0,\"topics\":[{\"brokerid\":\"ha\",\"topic\":\"buttonplus/wk1/button/4/state\",\"payload\":\"4\",\"eventtype\":0},{\"brokerid\":\"ha\",\"topic\":\"buttonplus/wk1/button/4/longpress\",\"payload\":\"4\",\"eventtype\":1},{\"brokerid\":\"ha\",\"topic\":\"buttonplus/wk1/button/4/label\",\"payload\":\"\",\"eventtype\":11},{\"brokerid\":\"ha\",\"topic\":\"buttonplus/wk1/button/4/toplabel\",\"payload\":\"\",\"eventtype\":12},{\"brokerid\":\"ha\",\"topic\":\"buttonplus/wk1/button/4/ledrgb\",\"payload\":\"\",\"eventtype\":13},{\"brokerid\":\"ha\",\"topic\":\"buttonplus/wk1/button/4/led\",\"payload\":\"on\",\"eventtype\":14}]},{\"id\":5,\"label\":\"Next\",\"toplabel\":\"5\",\"ledcolorfront\":0,\"ledcolorwall\":0,\"topics\":[{\"brokerid\":\"ha\",\"topic\":\"buttonplus/wk1/button/5/state\",\"payload\":\"5\",\"eventtype\":0},{\"brokerid\":\"ha\",\"topic\":\"buttonplus/wk1/button/5/longpress\",\"payload\":\"5\",\"eventtype\":1},{\"brokerid\":\"ha\",\"topic\":\"buttonplus/wk1/button/5/label\",\"payload\":\"\",\"eventtype\":11},{\"brokerid\":\"ha\",\"topic\":\"buttonplus/wk1/button/5/toplabel\",\"payload\":\"\",\"eventtype\":12},{\"brokerid\":\"ha\",\"topic\":\"buttonplus/wk1/button/5/ledrgb\",\"payload\":\"\",\"eventtype\":13},{\"brokerid\":\"ha\",\"topic\":\"buttonplus/wk1/button/5/led\",\"payload\":\"on\",\"eventtype\":14}]},{\"id\":6,\"label\":\"-\",\"toplabel\":\"6\",\"ledcolorfront\":0,\"ledcolorwall\":0,\"topics\":[{\"brokerid\":\"ha\",\"topic\":\"buttonplus/wk1/button/6/state\",\"payload\":\"6\",\"eventtype\":0},{\"brokerid\":\"ha\",\"topic\":\"buttonplus/wk1/button/6/longpress\",\"payload\":\"6\",\"eventtype\":1},{\"brokerid\":\"ha\",\"topic\":\"buttonplus/wk1/button/6/label\",\"payload\":\"\",\"eventtype\":11},{\"brokerid\":\"ha\",\"topic\":\"buttonplus/wk1/button/6/toplabel\",\"payload\":\"\",\"eventtype\":12},{\"brokerid\":\"ha\",\"topic\":\"buttonplus/wk1/button/6/ledrgb\",\"payload\":\"\",\"eventtype\":13},{\"brokerid\":\"ha\",\"topic\":\"buttonplus/wk1/button/6/led\",\"payload\":\"on\",\"eventtype\":14}]},{\"id\":7,\"label\":\"+\",\"toplabel\":\"7\",\"ledcolorfront\":0,\"ledcolorwall\":0,\"topics\":[{\"brokerid\":\"ha\",\"topic\":\"buttonplus/wk1/button/7/state\",\"payload\":\"7\",\"eventtype\":0},{\"brokerid\":\"ha\",\"topic\":\"buttonplus/wk1/button/7/longpress\",\"payload\":\"7\",\"eventtype\":1},{\"brokerid\":\"ha\",\"topic\":\"buttonplus/wk1/button/7/label\",\"payload\":\"\",\"eventtype\":11},{\"brokerid\":\"ha\",\"topic\":\"buttonplus/wk1/button/7/toplabel\",\"payload\":\"\",\"eventtype\":12},{\"brokerid\":\"ha\",\"topic\":\"buttonplus/wk1/button/7/ledrgb\",\"payload\":\"\",\"eventtype\":13},{\"brokerid\":\"ha\",\"topic\":\"buttonplus/wk1/button/7/led\",\"payload\":\"on\",\"eventtype\":14}]}],\"mqttdisplays\":[{\"x\":1,\"y\":1,\"fontsize\":2,\"align\":8,\"width\":25,\"label\":\"Dit is een label\",\"unit\":\"°C\",\"round\":1,\"topics\":[{\"brokerid\":\"ha\",\"topic\":\"buttonplus/wk1/display/1/value\",\"payload\":\"\",\"eventtype\":15},{\"brokerid\":\"ha\",\"topic\":\"buttonplus/wk1/display/1/label\",\"payload\":\"\",\"eventtype\":16},{\"brokerid\":\"ha\",\"topic\":\"buttonplus/wk1/display/1/uom\",\"payload\":\"\",\"eventtype\":17}]},{\"x\":30,\"y\":1,\"fontsize\":2,\"align\":0,\"width\":25,\"label\":\"Dit is een label2\",\"unit\":\"°C\",\"round\":0,\"topics\":[{\"brokerid\":\"ha\",\"topic\":\"buttonplus/wk1/display/2/value\",\"payload\":\"\",\"eventtype\":15},{\"brokerid\":\"ha\",\"topic\":\"buttonplus/wk1/display/2/label\",\"payload\":\"\",\"eventtype\":16},{\"brokerid\":\"ha\",\"topic\":\"buttonplus/wk1/display/2/uom\",\"payload\":\"\",\"eventtype\":17}]},{\"x\":0,\"y\":50,\"fontsize\":2,\"align\":8,\"width\":50,\"label\":\"Temperatuur\",\"unit\":\"\",\"round\":0,\"topics\":[{\"brokerid\":\"ha\",\"topic\":\"buttonplus/wk1/display/3/value\",\"payload\":\"\",\"eventtype\":15},{\"brokerid\":\"ha\",\"topic\":\"buttonplus/wk1/display/3/label\",\"payload\":\"\",\"eventtype\":16},{\"brokerid\":\"ha\",\"topic\":\"buttonplus/wk1/display/3/uom\",\"payload\":\"\",\"eventtype\":17}]},{\"x\":0,\"y\":20,\"fontsize\":1,\"align\":0,\"width\":100,\"label\":\"Dit is een label2\",\"unit\":\"°CC\",\"round\":0,\"topics\":[{\"brokerid\":\"ha\",\"topic\":\"buttonplus/wk1/display/4/value\",\"payload\":\"\",\"eventtype\":15},{\"brokerid\":\"ha\",\"topic\":\"buttonplus/wk1/display/4/label\",\"payload\":\"\",\"eventtype\":16},{\"brokerid\":\"ha\",\"topic\":\"buttonplus/wk1/display/4/uom\",\"payload\":\"\",\"eventtype\":17}]},{\"x\":70,\"y\":72,\"fontsize\":1,\"align\":0,\"width\":30,\"label\":\"Menu\",\"unit\":\"\",\"round\":0,\"topics\":[{\"brokerid\":\"ha\",\"topic\":\"buttonplus/wk1/display/5/value\",\"payload\":\"\",\"eventtype\":15},{\"brokerid\":\"ha\",\"topic\":\"buttonplus/wk1/display/5/label\",\"payload\":\"\",\"eventtype\":16},{\"brokerid\":\"ha\",\"topic\":\"buttonplus/wk1/display/5/uom\",\"payload\":\"\",\"eventtype\":17}]}],\"mqttbrokers\":[{\"brokerid\":\"buttonplus\",\"url\":\"mqtt://mqtt.button.plus\",\"port\":0,\"wsport\":0,\"username\":\"\",\"password\":\"\"},{\"brokerid\":\"ha\",\"url\":\"mqtt://192.168.1.7\",\"port\":1883,\"wsport\":0,\"username\":\"mqtt\",\"password\":\"mqtt\"}],\"mqttsensors\":[{\"sensorid\":1,\"topic\":{\"brokerid\":\"buttonplus\",\"topic\":\"button/btn_45a424/temperature\",\"payload\":\"\",\"eventtype\":18},\"interval\":10}]}'\nmsg.payload = configJSON;\nreturn msg;","outputs":1,"timeout":0,"noerr":0,"initialize":"","finalize":"","libs":[],"x":280,"y":1280,"wires":[["45ab88b641cd1844"]]},{"id":"2451fd3fe6f4505d","type":"inject","z":"857c75046ddd42f1","name":"","props":[{"p":"payload"},{"p":"topic","vt":"str"}],"repeat":"","crontab":"","once":false,"onceDelay":0.1,"topic":"","payload":"","payloadType":"date","x":100,"y":1280,"wires":[["868b82c96c710c61"]]},{"id":"d3a1457f2b169f39","type":"comment","z":"857c75046ddd42f1","name":"Default config","info":"","x":110,"y":1220,"wires":[]},{"id":"258311fdb53399c1","type":"function","z":"857c75046ddd42f1","name":"prepare MQTT topics","func":"function sleep(ms) {\n    return new Promise((resolve) => {\n        setTimeout(resolve, ms);\n    });\n}\nfor (var i in msg.label){\n    var newMsg = {};\n    // send label\n    newMsg.payload = msg.label[i];\n    if (newMsg.payload == \"\") { newMsg.payload = \" \" }\n    newMsg.topic = msg.topic+i+\"/label\";\n    node.send(newMsg);\n    await sleep(20);\n\n    // send toplabel\n    newMsg.payload = msg.toplabel[i];\n    if (newMsg.payload == \"\") { newMsg.payload = \" \" }\n    newMsg.topic = msg.topic+i+\"/toplabel\";\n    node.send(newMsg);\n    await sleep(20);\n    // send led color\n    newMsg.payload = msg.ledrgb[i];\n    newMsg.topic = msg.topic+i+\"/ledrgb\";\n    node.send(newMsg);\n    await sleep(20);\n    // send led state\n    // newMsg.payload = msg.led[i];\n    // newMsg.topic = msg.topic + i + \"/led\";\n    // node.send(newMsg);\n    \n}\n\nreturn null;","outputs":1,"timeout":0,"noerr":0,"initialize":"","finalize":"","libs":[],"x":1580,"y":120,"wires":[["14b36c35e40cb1c5","79e87b37c19b4b2a"]]},{"id":"79e87b37c19b4b2a","type":"mqtt out","z":"857c75046ddd42f1","name":"Update buttons","topic":"","qos":"2","retain":"true","respTopic":"","contentType":"","userProps":"","correl":"","expiry":"","broker":"e6dbd5fb3f32ec20","x":1940,"y":120,"wires":[]},{"id":"77a19e23a13c5e5b","type":"change","z":"857c75046ddd42f1","name":"draw Verlichting label","rules":[{"t":"set","p":"label.0","pt":"msg","to":"Slaapstand","tot":"str"},{"t":"set","p":"label.1","pt":"msg","to":"Avond","tot":"str"},{"t":"set","p":"label.2","pt":"msg","to":"","tot":"str"},{"t":"set","p":"label.3","pt":"msg","to":"","tot":"str"},{"t":"set","p":"label.4","pt":"msg","to":"Avond mid","tot":"str"},{"t":"set","p":"label.5","pt":"msg","to":"Avond dim","tot":"str"},{"t":"set","p":"label.6","pt":"msg","to":"Slaapstand","tot":"str"},{"t":"set","p":"label.7","pt":"msg","to":"Avond vol","tot":"str"},{"t":"set","p":"toplabel.0","pt":"msg","to":" ","tot":"str"},{"t":"set","p":"toplabel.1","pt":"msg","to":"1","tot":"str"},{"t":"set","p":"toplabel.2","pt":"msg","to":"","tot":"str"},{"t":"set","p":"toplabel.3","pt":"msg","to":"","tot":"str"},{"t":"set","p":"toplabel.4","pt":"msg","to":"Verlichting","tot":"str"},{"t":"set","p":"toplabel.5","pt":"msg","to":"Verlichting","tot":"str"},{"t":"set","p":"toplabel.6","pt":"msg","to":"Alles uit","tot":"str"},{"t":"set","p":"toplabel.7","pt":"msg","to":"Verlichting","tot":"str"},{"t":"set","p":"title","pt":"msg","to":"Verlichting","tot":"str"},{"t":"set","p":"ledrgb.0","pt":"msg","to":"0","tot":"num"},{"t":"set","p":"ledrgb.1","pt":"msg","to":"0","tot":"num"},{"t":"set","p":"ledrgb.2","pt":"msg","to":"0","tot":"num"},{"t":"set","p":"ledrgb.3","pt":"msg","to":"0","tot":"num"},{"t":"set","p":"ledrgb.4","pt":"msg","to":"0","tot":"num"},{"t":"set","p":"ledrgb.5","pt":"msg","to":"0","tot":"num"},{"t":"set","p":"ledrgb.6","pt":"msg","to":"0","tot":"num"},{"t":"set","p":"ledrgb.7","pt":"msg","to":"0","tot":"num"}],"action":"","property":"","from":"","to":"","reg":false,"x":820,"y":60,"wires":[["258311fdb53399c1","60a9b14f03b54ea6","c11b6c2e45595806","607a55b1c7f5a0c5","6cab083c6367c424"]]},{"id":"67316341f1c98e74","type":"change","z":"857c75046ddd42f1","name":"draw Overdag label","rules":[{"t":"set","p":"label.0","pt":"msg","to":"Slaapstand","tot":"str"},{"t":"set","p":"label.1","pt":"msg","to":"o1","tot":"str"},{"t":"set","p":"label.2","pt":"msg","to":"","tot":"str"},{"t":"set","p":"label.3","pt":"msg","to":"","tot":"str"},{"t":"set","p":"label.4","pt":"msg","to":"","tot":"str"},{"t":"set","p":"label.5","pt":"msg","to":"Alles aan","tot":"str"},{"t":"set","p":"label.6","pt":"msg","to":"Vertrekken","tot":"str"},{"t":"set","p":"label.7","pt":"msg","to":"Ochtend","tot":"str"},{"t":"set","p":"toplabel.0","pt":"msg","to":" ","tot":"str"},{"t":"set","p":"toplabel.1","pt":"msg","to":"1","tot":"str"},{"t":"set","p":"toplabel.2","pt":"msg","to":"","tot":"str"},{"t":"set","p":"toplabel.3","pt":"msg","to":"","tot":"str"},{"t":"set","p":"toplabel.4","pt":"msg","to":"","tot":"str"},{"t":"set","p":"toplabel.5","pt":"msg","to":"Verlichting","tot":"str"},{"t":"set","p":"toplabel.6","pt":"msg","to":"Alles uit","tot":"str"},{"t":"set","p":"toplabel.7","pt":"msg","to":"Verlichting","tot":"str"},{"t":"set","p":"title","pt":"msg","to":"Overdag","tot":"str"},{"t":"set","p":"ledrgb.0","pt":"msg","to":"0","tot":"num"},{"t":"set","p":"ledrgb.1","pt":"msg","to":"0","tot":"num"},{"t":"set","p":"ledrgb.2","pt":"msg","to":"0","tot":"num"},{"t":"set","p":"ledrgb.3","pt":"msg","to":"0","tot":"num"},{"t":"set","p":"ledrgb.4","pt":"msg","to":"0","tot":"num"},{"t":"set","p":"ledrgb.5","pt":"msg","to":"0","tot":"num"},{"t":"set","p":"ledrgb.6","pt":"msg","to":"0","tot":"num"},{"t":"set","p":"ledrgb.7","pt":"msg","to":"0","tot":"num"}],"action":"","property":"","from":"","to":"","reg":false,"x":810,"y":180,"wires":[["258311fdb53399c1","c11b6c2e45595806","017754c6130107f7","6cab083c6367c424","448d40eac0f05ff7"]]},{"id":"c11b6c2e45595806","type":"api-current-state","z":"857c75046ddd42f1","name":"","server":"c5f56a3a.f3f838","version":3,"outputs":1,"halt_if":"","halt_if_type":"str","halt_if_compare":"is","entity_id":"sensor.buienalarm_precipitation_forecast_total","state_type":"str","blockInputOverrides":true,"outputProperties":[{"property":"payload","propertyType":"msg","value":"","valueType":"entityState"},{"property":"data","propertyType":"msg","value":"","valueType":"entity"},{"property":"uom","propertyType":"msg","value":"$entity().attributes.unit_of_measurement","valueType":"jsonata"},{"property":"label","propertyType":"msg","value":"$entity().attributes.friendly_name","valueType":"jsonata"},{"property":"displayitem","propertyType":"msg","value":"3","valueType":"str"},{"property":"device","propertyType":"msg","value":"wk1","valueType":"str"}],"for":"0","forType":"num","forUnits":"minutes","override_topic":false,"state_location":"payload","override_payload":"msg","entity_location":"data","override_data":"msg","x":1520,"y":360,"wires":[["1d74f413fc65de04"]]},{"id":"c7bf776f416a1afb","type":"server-state-changed","z":"857c75046ddd42f1","name":"","server":"c5f56a3a.f3f838","version":5,"outputs":1,"exposeAsEntityConfig":"","entityId":"sensor.buienalarm_precipitation_forecast_total","entityIdType":"exact","outputInitially":false,"stateType":"str","ifState":"","ifStateType":"str","ifStateOperator":"is","outputOnlyOnStateChange":true,"for":"0","forType":"num","forUnits":"minutes","ignorePrevStateNull":false,"ignorePrevStateUnknown":false,"ignorePrevStateUnavailable":false,"ignoreCurrentStateUnknown":false,"ignoreCurrentStateUnavailable":false,"outputProperties":[{"property":"payload","propertyType":"msg","value":"","valueType":"entityState"},{"property":"data","propertyType":"msg","value":"","valueType":"eventData"},{"property":"topic","propertyType":"msg","value":"","valueType":"triggerId"},{"property":"uom","propertyType":"msg","value":"$entity().attributes.unit_of_measurement","valueType":"jsonata"},{"property":"label","propertyType":"msg","value":"$entity().attributes.friendly_name","valueType":"jsonata"},{"property":"displayitem","propertyType":"msg","value":"3","valueType":"str"},{"property":"device","propertyType":"msg","value":"wk1","valueType":"str"}],"x":1510,"y":420,"wires":[["5dc2db486022be82"]]},{"id":"5b0e622720f31669","type":"server-state-changed","z":"857c75046ddd42f1","name":"Woonkamer temperatuur","server":"c5f56a3a.f3f838","version":5,"outputs":1,"exposeAsEntityConfig":"","entityId":"sensor.woonkamer_temperature","entityIdType":"exact","outputInitially":true,"stateType":"num","ifState":"","ifStateType":"str","ifStateOperator":"is","outputOnlyOnStateChange":true,"for":"0","forType":"num","forUnits":"minutes","ignorePrevStateNull":false,"ignorePrevStateUnknown":false,"ignorePrevStateUnavailable":false,"ignoreCurrentStateUnknown":false,"ignoreCurrentStateUnavailable":false,"outputProperties":[{"property":"payload","propertyType":"msg","value":"","valueType":"entityState"},{"property":"uom","propertyType":"msg","value":"$entity().attributes.unit_of_measurement","valueType":"jsonata"},{"property":"label","propertyType":"msg","value":"$entity().attributes.friendly_name","valueType":"jsonata"},{"property":"displayitem","propertyType":"msg","value":"1","valueType":"str"},{"property":"device","propertyType":"msg","value":"wk1","valueType":"str"}],"x":1610,"y":500,"wires":[[]]},{"id":"8ce7856aaea32ad0","type":"mqtt out","z":"857c75046ddd42f1","name":"","topic":"","qos":"2","retain":"","respTopic":"","contentType":"","userProps":"","correl":"","expiry":"","broker":"e6dbd5fb3f32ec20","x":1550,"y":200,"wires":[]},{"id":"6cab083c6367c424","type":"function","z":"857c75046ddd42f1","name":"Send title","func":"var title = msg.title;\nmsg = {};\nmsg.topic = \"buttonplus/wk1/display/5/value\";\nmsg.qos = 2;\nmsg.payload = title;\nmsg.retain = true;\nreturn msg;","outputs":1,"timeout":0,"noerr":0,"initialize":"","finalize":"","libs":[],"x":1280,"y":200,"wires":[["8ce7856aaea32ad0","7d22e38f463359d1"]]},{"id":"7e2329155f830517","type":"server-state-changed","z":"857c75046ddd42f1","name":"","server":"c5f56a3a.f3f838","version":5,"outputs":1,"exposeAsEntityConfig":"","entityId":"sensor.buttonplus_prio_notification","entityIdType":"exact","outputInitially":false,"stateType":"str","ifState":"","ifStateType":"str","ifStateOperator":"is","outputOnlyOnStateChange":true,"for":"0","forType":"num","forUnits":"minutes","ignorePrevStateNull":false,"ignorePrevStateUnknown":false,"ignorePrevStateUnavailable":false,"ignoreCurrentStateUnknown":false,"ignoreCurrentStateUnavailable":false,"outputProperties":[{"property":"payload","propertyType":"msg","value":"","valueType":"entityState"},{"property":"data","propertyType":"msg","value":"","valueType":"eventData"},{"property":"topic","propertyType":"msg","value":"","valueType":"triggerId"},{"property":"label","propertyType":"msg","value":"$entity(). attributes.label","valueType":"jsonata"},{"property":"toplabel","propertyType":"msg","value":"$entity().attributes.toplabel","valueType":"jsonata"},{"property":"ledrgb","propertyType":"msg","value":"$entity().attributes.frontled","valueType":"jsonata"},{"property":"topic","propertyType":"msg","value":"buttonplus/wk1/button/2","valueType":"str"}],"x":1890,"y":620,"wires":[["ea626897b6a3cf43"]]},{"id":"ea626897b6a3cf43","type":"function","z":"857c75046ddd42f1","name":"prepare MQTT topics","func":"function sleep(ms) {\n    return new Promise((resolve) => {\n        setTimeout(resolve, ms);\n    });\n}\n\nvar newMsg = {};\n// send label\nnewMsg.payload = msg.label;\nif (newMsg.payload == \"\") { newMsg.payload = \" \" }\nnewMsg.topic = msg.topic+\"/label\";\nnode.send(newMsg);\nawait sleep(20);\n\n// send toplabel\nnewMsg.payload = msg.toplabel;\nif (newMsg.payload == \"\") { newMsg.payload = \" \" }\nnewMsg.topic = msg.topic+\"/toplabel\";\nnode.send(newMsg);\nawait sleep(20);\n// send led color\nnewMsg.payload = msg.ledrgb;\nnewMsg.topic = msg.topic+\"/ledrgb\";\nnode.send(newMsg);\nawait sleep(20);\n// send led state\n// newMsg.payload = msg.led[i];\n// newMsg.topic = msg.topic + i + \"/led\";\n// node.send(newMsg);\n\n\n\nreturn null;","outputs":1,"timeout":0,"noerr":0,"initialize":"","finalize":"","libs":[],"x":2220,"y":620,"wires":[["fe9e73815d079a80"]]},{"id":"fe9e73815d079a80","type":"mqtt out","z":"857c75046ddd42f1","name":"Update buttons","topic":"","qos":"2","retain":"true","respTopic":"","contentType":"","userProps":"","correl":"","expiry":"","broker":"e6dbd5fb3f32ec20","x":2440,"y":620,"wires":[]},{"id":"3c5f8e952a73f01e","type":"inject","z":"857c75046ddd42f1","name":"displayitem6","props":[{"p":"displayitem","v":"6","vt":"num"},{"p":"x","v":"70","vt":"num"},{"p":"y","v":"0","vt":"num"},{"p":"fontsize","v":"3","vt":"num"},{"p":"width","v":"30","vt":"num"},{"p":"label","v":"","vt":"str"},{"p":"unit","v":"","vt":"str"},{"p":"round","v":"0","vt":"num"},{"p":"align","v":"0","vt":"str"}],"repeat":"","crontab":"","once":false,"onceDelay":0.1,"topic":"","x":490,"y":880,"wires":[["8c681f70135aae74"]]},{"id":"467f87c9384345da","type":"inject","z":"857c75046ddd42f1","name":"delete6","props":[{"p":"delete","v":"true","vt":"bool"},{"p":"displayitem","v":"5","vt":"num"}],"repeat":"","crontab":"","once":false,"onceDelay":0.1,"topic":"","x":470,"y":920,"wires":[["8c681f70135aae74"]]},{"id":"34c322cd0d2b6445","type":"comment","z":"857c75046ddd42f1","name":"6 = tijd","info":"","x":450,"y":840,"wires":[]},{"id":"1b29e54f9726edf7","type":"comment","z":"857c75046ddd42f1","name":"3: regen","info":"","x":480,"y":520,"wires":[]},{"id":"5ec3629b877e342b","type":"comment","z":"857c75046ddd42f1","name":"1: gemeten","info":"","x":160,"y":480,"wires":[]},{"id":"9f4b19034ff884ec","type":"comment","z":"857c75046ddd42f1","name":"2: gewenst","info":"","x":80,"y":600,"wires":[]},{"id":"89cc41edcdef8c73","type":"function","z":"857c75046ddd42f1","name":"function 3","func":"var mmpu = msg.payload*4;\nvar description;\nif (mmpu ==0){\n    description = \"(droog)\";\n} else if (mmpu < 1) {\n    description = \"(licht)\";\n} else if (mmpu < 5) {\n    description = \"(matig)\";\n} else {\n    description = \"(zwaar)\";\n}\nmsg.payload = mmpu.toString()+\" mm/u \"+description;\nreturn msg;","outputs":1,"timeout":0,"noerr":0,"initialize":"","finalize":"","libs":[],"x":2180,"y":240,"wires":[["5434edf396d3fb0c","31581b9ca2133cbf"]]}]
+[
+    {
+        "id": "9fafc27b6f107add",
+        "type": "subflow",
+        "name": "Main",
+        "info": "",
+        "category": "",
+        "in": [
+            {
+                "x": 40,
+                "y": 140,
+                "wires": [
+                    {
+                        "id": "ed48a4366bab24de"
+                    }
+                ]
+            }
+        ],
+        "out": [
+            {
+                "x": 660,
+                "y": 280,
+                "wires": []
+            },
+            {
+                "x": 680,
+                "y": 320,
+                "wires": [
+                    {
+                        "id": "d0d44f1d535dd25c",
+                        "port": 1
+                    }
+                ]
+            }
+        ],
+        "env": [],
+        "meta": {},
+        "color": "#DDAA99"
+    },
+    {
+        "id": "ed48a4366bab24de",
+        "type": "switch",
+        "z": "9fafc27b6f107add",
+        "name": "",
+        "property": "action_type",
+        "propertyType": "msg",
+        "rules": [
+            {
+                "t": "eq",
+                "v": "click",
+                "vt": "str"
+            },
+            {
+                "t": "eq",
+                "v": "release",
+                "vt": "str"
+            }
+        ],
+        "checkall": "true",
+        "repair": false,
+        "outputs": 2,
+        "x": 150,
+        "y": 140,
+        "wires": [
+            [
+                "d0d44f1d535dd25c"
+            ],
+            [
+                "9737cabeb9fdb9c4"
+            ]
+        ]
+    },
+    {
+        "id": "d0d44f1d535dd25c",
+        "type": "switch",
+        "z": "9fafc27b6f107add",
+        "name": "Click",
+        "property": "btn_click",
+        "propertyType": "msg",
+        "rules": [
+            {
+                "t": "eq",
+                "v": "0",
+                "vt": "str"
+            },
+            {
+                "t": "eq",
+                "v": "1",
+                "vt": "str"
+            },
+            {
+                "t": "eq",
+                "v": "2",
+                "vt": "str"
+            },
+            {
+                "t": "eq",
+                "v": "3",
+                "vt": "str"
+            },
+            {
+                "t": "eq",
+                "v": "4",
+                "vt": "str"
+            },
+            {
+                "t": "eq",
+                "v": "5",
+                "vt": "str"
+            },
+            {
+                "t": "eq",
+                "v": "6",
+                "vt": "str"
+            },
+            {
+                "t": "eq",
+                "v": "7",
+                "vt": "str"
+            }
+        ],
+        "checkall": "true",
+        "repair": false,
+        "outputs": 8,
+        "x": 370,
+        "y": 160,
+        "wires": [
+            [],
+            [
+                "0fd3958b060ec2f2"
+            ],
+            [
+                "69efab6a059210b6"
+            ],
+            [],
+            [],
+            [],
+            [],
+            []
+        ]
+    },
+    {
+        "id": "9737cabeb9fdb9c4",
+        "type": "switch",
+        "z": "9fafc27b6f107add",
+        "name": "Release",
+        "property": "btn_release",
+        "propertyType": "msg",
+        "rules": [
+            {
+                "t": "eq",
+                "v": "btn_1l",
+                "vt": "str"
+            },
+            {
+                "t": "eq",
+                "v": "btn_1r",
+                "vt": "str"
+            },
+            {
+                "t": "eq",
+                "v": "btn_2l",
+                "vt": "str"
+            },
+            {
+                "t": "eq",
+                "v": "btn_2r",
+                "vt": "str"
+            },
+            {
+                "t": "eq",
+                "v": "btn_3l",
+                "vt": "str"
+            },
+            {
+                "t": "eq",
+                "v": "btn_3r",
+                "vt": "str"
+            },
+            {
+                "t": "eq",
+                "v": "btn_4l",
+                "vt": "str"
+            },
+            {
+                "t": "eq",
+                "v": "btn_4r",
+                "vt": "str"
+            }
+        ],
+        "checkall": "true",
+        "repair": false,
+        "outputs": 8,
+        "x": 180,
+        "y": 340,
+        "wires": [
+            [],
+            [],
+            [],
+            [],
+            [],
+            [],
+            [],
+            []
+        ]
+    },
+    {
+        "id": "0fd3958b060ec2f2",
+        "type": "api-call-service",
+        "z": "9fafc27b6f107add",
+        "name": "next menu",
+        "server": "c5f56a3a.f3f838",
+        "version": 5,
+        "debugenabled": false,
+        "domain": "input_select",
+        "service": "select_next",
+        "areaId": [],
+        "deviceId": [],
+        "entityId": [
+            "input_select.buttonplus_wk1_menuselector"
+        ],
+        "data": "",
+        "dataType": "jsonata",
+        "mergeContext": "",
+        "mustacheAltTags": false,
+        "outputProperties": [],
+        "queue": "none",
+        "x": 670,
+        "y": 140,
+        "wires": [
+            []
+        ]
+    },
+    {
+        "id": "69efab6a059210b6",
+        "type": "api-call-service",
+        "z": "9fafc27b6f107add",
+        "name": "B+ clear prio",
+        "server": "c5f56a3a.f3f838",
+        "version": 5,
+        "debugenabled": false,
+        "domain": "script",
+        "service": "buttonplus_notification_clear_prio",
+        "areaId": [],
+        "deviceId": [],
+        "entityId": [],
+        "data": "",
+        "dataType": "jsonata",
+        "mergeContext": "",
+        "mustacheAltTags": false,
+        "outputProperties": [],
+        "queue": "none",
+        "x": 690,
+        "y": 200,
+        "wires": [
+            []
+        ]
+    },
+    {
+        "id": "3f278483a074ca1c",
+        "type": "subflow",
+        "name": "Overdag",
+        "info": "",
+        "category": "",
+        "in": [
+            {
+                "x": 50,
+                "y": 30,
+                "wires": [
+                    {
+                        "id": "64813ca6fc6f35be"
+                    }
+                ]
+            }
+        ],
+        "out": [
+            {
+                "x": 700,
+                "y": 80,
+                "wires": []
+            },
+            {
+                "x": 740,
+                "y": 280,
+                "wires": []
+            },
+            {
+                "x": 720,
+                "y": 180,
+                "wires": []
+            }
+        ],
+        "env": [],
+        "meta": {},
+        "color": "#DDAA99"
+    },
+    {
+        "id": "64813ca6fc6f35be",
+        "type": "switch",
+        "z": "3f278483a074ca1c",
+        "name": "",
+        "property": "action_type",
+        "propertyType": "msg",
+        "rules": [
+            {
+                "t": "eq",
+                "v": "click",
+                "vt": "str"
+            },
+            {
+                "t": "eq",
+                "v": "release",
+                "vt": "str"
+            },
+            {
+                "t": "else"
+            }
+        ],
+        "checkall": "true",
+        "repair": false,
+        "outputs": 3,
+        "x": 150,
+        "y": 80,
+        "wires": [
+            [
+                "47b85f522b41fbbf"
+            ],
+            [],
+            []
+        ]
+    },
+    {
+        "id": "47b85f522b41fbbf",
+        "type": "switch",
+        "z": "3f278483a074ca1c",
+        "name": "",
+        "property": "btn_click",
+        "propertyType": "msg",
+        "rules": [
+            {
+                "t": "eq",
+                "v": "0",
+                "vt": "str"
+            },
+            {
+                "t": "eq",
+                "v": "1",
+                "vt": "str"
+            },
+            {
+                "t": "eq",
+                "v": "2",
+                "vt": "str"
+            },
+            {
+                "t": "eq",
+                "v": "3",
+                "vt": "str"
+            },
+            {
+                "t": "eq",
+                "v": "4",
+                "vt": "str"
+            },
+            {
+                "t": "eq",
+                "v": "5",
+                "vt": "str"
+            },
+            {
+                "t": "eq",
+                "v": "6",
+                "vt": "str"
+            },
+            {
+                "t": "eq",
+                "v": "7",
+                "vt": "str"
+            }
+        ],
+        "checkall": "true",
+        "repair": false,
+        "outputs": 8,
+        "x": 290,
+        "y": 280,
+        "wires": [
+            [],
+            [],
+            [],
+            [],
+            [],
+            [
+                "b10720159d610313"
+            ],
+            [
+                "cd561af46a31eef9"
+            ],
+            [
+                "4c1e21bb771abaae"
+            ]
+        ]
+    },
+    {
+        "id": "4c1e21bb771abaae",
+        "type": "api-call-service",
+        "z": "3f278483a074ca1c",
+        "name": "Ochtend aan",
+        "server": "c5f56a3a.f3f838",
+        "version": 5,
+        "debugenabled": false,
+        "domain": "scene",
+        "service": "turn_on",
+        "areaId": [
+            "f003303ef40d4f74a22d0ac43952a198"
+        ],
+        "deviceId": [],
+        "entityId": [
+            "scene.ochtend_aan"
+        ],
+        "data": "",
+        "dataType": "jsonata",
+        "mergeContext": "",
+        "mustacheAltTags": false,
+        "outputProperties": [],
+        "queue": "none",
+        "x": 710,
+        "y": 440,
+        "wires": [
+            []
+        ]
+    },
+    {
+        "id": "cd561af46a31eef9",
+        "type": "api-call-service",
+        "z": "3f278483a074ca1c",
+        "name": "",
+        "server": "c5f56a3a.f3f838",
+        "version": 5,
+        "debugenabled": false,
+        "domain": "script",
+        "service": "woonkamer_lichten_uit",
+        "areaId": [],
+        "deviceId": [],
+        "entityId": [],
+        "data": "",
+        "dataType": "jsonata",
+        "mergeContext": "",
+        "mustacheAltTags": false,
+        "outputProperties": [],
+        "queue": "none",
+        "x": 480,
+        "y": 440,
+        "wires": [
+            []
+        ]
+    },
+    {
+        "id": "b10720159d610313",
+        "type": "api-call-service",
+        "z": "3f278483a074ca1c",
+        "name": "Woonkamer vol",
+        "server": "c5f56a3a.f3f838",
+        "version": 5,
+        "debugenabled": false,
+        "domain": "scene",
+        "service": "turn_on",
+        "areaId": [
+            "f003303ef40d4f74a22d0ac43952a198"
+        ],
+        "deviceId": [],
+        "entityId": [
+            "scene.woonkamer_vol"
+        ],
+        "data": "",
+        "dataType": "jsonata",
+        "mergeContext": "",
+        "mustacheAltTags": false,
+        "outputProperties": [],
+        "queue": "none",
+        "x": 720,
+        "y": 380,
+        "wires": [
+            []
+        ]
+    },
+    {
+        "id": "6b88b4fda81a741c",
+        "type": "subflow",
+        "name": "Muziek",
+        "info": "",
+        "category": "",
+        "in": [
+            {
+                "x": 40,
+                "y": 80,
+                "wires": [
+                    {
+                        "id": "cb068e69b8176d5f"
+                    }
+                ]
+            }
+        ],
+        "out": [
+            {
+                "x": 1080,
+                "y": 140,
+                "wires": []
+            },
+            {
+                "x": 620,
+                "y": 180,
+                "wires": [
+                    {
+                        "id": "f648896a3569bab7",
+                        "port": 1
+                    }
+                ]
+            },
+            {
+                "x": 800,
+                "y": 80,
+                "wires": [
+                    {
+                        "id": "cb068e69b8176d5f",
+                        "port": 0
+                    }
+                ]
+            }
+        ],
+        "env": [],
+        "meta": {},
+        "color": "#DDAA99"
+    },
+    {
+        "id": "cb068e69b8176d5f",
+        "type": "switch",
+        "z": "6b88b4fda81a741c",
+        "name": "",
+        "property": "action_type",
+        "propertyType": "msg",
+        "rules": [
+            {
+                "t": "eq",
+                "v": "click",
+                "vt": "str"
+            },
+            {
+                "t": "eq",
+                "v": "release",
+                "vt": "str"
+            }
+        ],
+        "checkall": "true",
+        "repair": false,
+        "outputs": 2,
+        "x": 210,
+        "y": 80,
+        "wires": [
+            [
+                "f648896a3569bab7"
+            ],
+            []
+        ]
+    },
+    {
+        "id": "f648896a3569bab7",
+        "type": "switch",
+        "z": "6b88b4fda81a741c",
+        "name": "",
+        "property": "btn_click",
+        "propertyType": "msg",
+        "rules": [
+            {
+                "t": "eq",
+                "v": "0",
+                "vt": "str"
+            },
+            {
+                "t": "eq",
+                "v": "1",
+                "vt": "str"
+            },
+            {
+                "t": "eq",
+                "v": "2",
+                "vt": "str"
+            },
+            {
+                "t": "eq",
+                "v": "3",
+                "vt": "str"
+            },
+            {
+                "t": "eq",
+                "v": "4",
+                "vt": "str"
+            },
+            {
+                "t": "eq",
+                "v": "5",
+                "vt": "str"
+            },
+            {
+                "t": "eq",
+                "v": "6",
+                "vt": "str"
+            },
+            {
+                "t": "eq",
+                "v": "7",
+                "vt": "str"
+            }
+        ],
+        "checkall": "true",
+        "repair": false,
+        "outputs": 8,
+        "x": 350,
+        "y": 280,
+        "wires": [
+            [],
+            [],
+            [],
+            [
+                "b3ede8c9cfcce4a7"
+            ],
+            [
+                "50c5c53183df6843"
+            ],
+            [
+                "63c0313088c7f320"
+            ],
+            [
+                "76a2ad845656e9e7"
+            ],
+            [
+                "2a291b5c19369515"
+            ]
+        ]
+    },
+    {
+        "id": "003e63908f635c91",
+        "type": "mqtt out",
+        "z": "6b88b4fda81a741c",
+        "name": "",
+        "topic": "buttonplus/wk1/music",
+        "qos": "",
+        "retain": "",
+        "respTopic": "",
+        "contentType": "",
+        "userProps": "",
+        "correl": "",
+        "expiry": "",
+        "broker": "e6dbd5fb3f32ec20",
+        "x": 840,
+        "y": 500,
+        "wires": []
+    },
+    {
+        "id": "2a291b5c19369515",
+        "type": "change",
+        "z": "6b88b4fda81a741c",
+        "name": "",
+        "rules": [
+            {
+                "t": "set",
+                "p": "payload",
+                "pt": "msg",
+                "to": "volumeup",
+                "tot": "str"
+            }
+        ],
+        "action": "",
+        "property": "",
+        "from": "",
+        "to": "",
+        "reg": false,
+        "x": 540,
+        "y": 500,
+        "wires": [
+            [
+                "003e63908f635c91"
+            ]
+        ]
+    },
+    {
+        "id": "76a2ad845656e9e7",
+        "type": "change",
+        "z": "6b88b4fda81a741c",
+        "name": "",
+        "rules": [
+            {
+                "t": "set",
+                "p": "payload",
+                "pt": "msg",
+                "to": "volumedown",
+                "tot": "str"
+            }
+        ],
+        "action": "",
+        "property": "",
+        "from": "",
+        "to": "",
+        "reg": false,
+        "x": 540,
+        "y": 440,
+        "wires": [
+            [
+                "003e63908f635c91"
+            ]
+        ]
+    },
+    {
+        "id": "63c0313088c7f320",
+        "type": "change",
+        "z": "6b88b4fda81a741c",
+        "name": "",
+        "rules": [
+            {
+                "t": "set",
+                "p": "payload",
+                "pt": "msg",
+                "to": "next",
+                "tot": "str"
+            }
+        ],
+        "action": "",
+        "property": "",
+        "from": "",
+        "to": "",
+        "reg": false,
+        "x": 540,
+        "y": 400,
+        "wires": [
+            [
+                "003e63908f635c91"
+            ]
+        ]
+    },
+    {
+        "id": "50c5c53183df6843",
+        "type": "change",
+        "z": "6b88b4fda81a741c",
+        "name": "",
+        "rules": [
+            {
+                "t": "set",
+                "p": "payload",
+                "pt": "msg",
+                "to": "previous",
+                "tot": "str"
+            }
+        ],
+        "action": "",
+        "property": "",
+        "from": "",
+        "to": "",
+        "reg": false,
+        "x": 540,
+        "y": 360,
+        "wires": [
+            [
+                "003e63908f635c91"
+            ]
+        ]
+    },
+    {
+        "id": "b3ede8c9cfcce4a7",
+        "type": "change",
+        "z": "6b88b4fda81a741c",
+        "name": "",
+        "rules": [
+            {
+                "t": "set",
+                "p": "payload",
+                "pt": "msg",
+                "to": "playpause",
+                "tot": "str"
+            }
+        ],
+        "action": "",
+        "property": "",
+        "from": "",
+        "to": "",
+        "reg": false,
+        "x": 540,
+        "y": 320,
+        "wires": [
+            [
+                "003e63908f635c91"
+            ]
+        ]
+    },
+    {
+        "id": "e6dbd5fb3f32ec20",
+        "type": "mqtt-broker",
+        "name": "",
+        "broker": "192.168.1.7",
+        "port": "1883",
+        "clientid": "",
+        "autoConnect": true,
+        "usetls": false,
+        "protocolVersion": "4",
+        "keepalive": "60",
+        "cleansession": true,
+        "birthTopic": "",
+        "birthQos": "0",
+        "birthPayload": "",
+        "birthMsg": {},
+        "closeTopic": "",
+        "closeQos": "0",
+        "closePayload": "",
+        "closeMsg": {},
+        "willTopic": "",
+        "willQos": "0",
+        "willPayload": "",
+        "willMsg": {},
+        "userProps": "",
+        "sessionExpiry": ""
+    },
+    {
+        "id": "e2ce48a0f1cc65ac",
+        "type": "subflow",
+        "name": "Verlichting",
+        "info": "",
+        "category": "",
+        "in": [
+            {
+                "x": 40,
+                "y": 80,
+                "wires": [
+                    {
+                        "id": "55c81e3cc9724857"
+                    }
+                ]
+            }
+        ],
+        "out": [
+            {
+                "x": 740,
+                "y": 240,
+                "wires": []
+            },
+            {
+                "x": 560,
+                "y": 160,
+                "wires": []
+            },
+            {
+                "x": 740,
+                "y": 360,
+                "wires": []
+            }
+        ],
+        "env": [],
+        "meta": {},
+        "color": "#DDAA99"
+    },
+    {
+        "id": "55c81e3cc9724857",
+        "type": "switch",
+        "z": "e2ce48a0f1cc65ac",
+        "name": "",
+        "property": "action_type",
+        "propertyType": "msg",
+        "rules": [
+            {
+                "t": "eq",
+                "v": "click",
+                "vt": "str"
+            },
+            {
+                "t": "eq",
+                "v": "release",
+                "vt": "str"
+            }
+        ],
+        "checkall": "true",
+        "repair": false,
+        "outputs": 2,
+        "x": 130,
+        "y": 80,
+        "wires": [
+            [
+                "ff8aabd46a802efc"
+            ],
+            [
+                "f3181072da1280de"
+            ]
+        ]
+    },
+    {
+        "id": "ff8aabd46a802efc",
+        "type": "switch",
+        "z": "e2ce48a0f1cc65ac",
+        "name": "Click",
+        "property": "btn_click",
+        "propertyType": "msg",
+        "rules": [
+            {
+                "t": "eq",
+                "v": "0",
+                "vt": "str"
+            },
+            {
+                "t": "eq",
+                "v": "1",
+                "vt": "str"
+            },
+            {
+                "t": "eq",
+                "v": "2",
+                "vt": "str"
+            },
+            {
+                "t": "eq",
+                "v": "3",
+                "vt": "str"
+            },
+            {
+                "t": "eq",
+                "v": "4",
+                "vt": "str"
+            },
+            {
+                "t": "eq",
+                "v": "5",
+                "vt": "str"
+            },
+            {
+                "t": "eq",
+                "v": "6",
+                "vt": "str"
+            },
+            {
+                "t": "eq",
+                "v": "7",
+                "vt": "str"
+            }
+        ],
+        "checkall": "true",
+        "repair": false,
+        "outputs": 8,
+        "x": 350,
+        "y": 100,
+        "wires": [
+            [],
+            [],
+            [],
+            [],
+            [
+                "c5f0eebafd0ff6c9"
+            ],
+            [
+                "b93b2de25909867b"
+            ],
+            [
+                "fb500ea153622b80"
+            ],
+            [
+                "76a71f967af5ab9d"
+            ]
+        ]
+    },
+    {
+        "id": "f3181072da1280de",
+        "type": "switch",
+        "z": "e2ce48a0f1cc65ac",
+        "name": "Release",
+        "property": "btn_release",
+        "propertyType": "msg",
+        "rules": [
+            {
+                "t": "eq",
+                "v": "btn_1l",
+                "vt": "str"
+            },
+            {
+                "t": "eq",
+                "v": "btn_1r",
+                "vt": "str"
+            },
+            {
+                "t": "eq",
+                "v": "btn_2l",
+                "vt": "str"
+            },
+            {
+                "t": "eq",
+                "v": "btn_2r",
+                "vt": "str"
+            },
+            {
+                "t": "eq",
+                "v": "btn_3l",
+                "vt": "str"
+            },
+            {
+                "t": "eq",
+                "v": "btn_3r",
+                "vt": "str"
+            },
+            {
+                "t": "eq",
+                "v": "btn_4l",
+                "vt": "str"
+            },
+            {
+                "t": "eq",
+                "v": "btn_4r",
+                "vt": "str"
+            }
+        ],
+        "checkall": "true",
+        "repair": false,
+        "outputs": 8,
+        "x": 160,
+        "y": 280,
+        "wires": [
+            [],
+            [],
+            [],
+            [],
+            [],
+            [],
+            [],
+            []
+        ]
+    },
+    {
+        "id": "fb500ea153622b80",
+        "type": "api-call-service",
+        "z": "e2ce48a0f1cc65ac",
+        "name": "",
+        "server": "c5f56a3a.f3f838",
+        "version": 5,
+        "debugenabled": false,
+        "domain": "script",
+        "service": "woonkamer_lichten_uit",
+        "areaId": [],
+        "deviceId": [],
+        "entityId": [],
+        "data": "",
+        "dataType": "jsonata",
+        "mergeContext": "",
+        "mustacheAltTags": false,
+        "outputProperties": [],
+        "queue": "none",
+        "x": 540,
+        "y": 480,
+        "wires": [
+            []
+        ]
+    },
+    {
+        "id": "76a71f967af5ab9d",
+        "type": "api-call-service",
+        "z": "e2ce48a0f1cc65ac",
+        "name": "Woonkamer vol",
+        "server": "c5f56a3a.f3f838",
+        "version": 5,
+        "debugenabled": false,
+        "domain": "scene",
+        "service": "turn_on",
+        "areaId": [
+            "f003303ef40d4f74a22d0ac43952a198"
+        ],
+        "deviceId": [],
+        "entityId": [
+            "scene.woonkamer_vol"
+        ],
+        "data": "",
+        "dataType": "jsonata",
+        "mergeContext": "",
+        "mustacheAltTags": false,
+        "outputProperties": [],
+        "queue": "none",
+        "x": 780,
+        "y": 480,
+        "wires": [
+            []
+        ]
+    },
+    {
+        "id": "c5f0eebafd0ff6c9",
+        "type": "api-call-service",
+        "z": "e2ce48a0f1cc65ac",
+        "name": "Woonkamer mid",
+        "server": "c5f56a3a.f3f838",
+        "version": 5,
+        "debugenabled": false,
+        "domain": "scene",
+        "service": "turn_on",
+        "areaId": [
+            "f003303ef40d4f74a22d0ac43952a198"
+        ],
+        "deviceId": [],
+        "entityId": [
+            "scene.woonkamer_mid"
+        ],
+        "data": "",
+        "dataType": "jsonata",
+        "mergeContext": "",
+        "mustacheAltTags": false,
+        "outputProperties": [],
+        "queue": "none",
+        "x": 500,
+        "y": 420,
+        "wires": [
+            []
+        ]
+    },
+    {
+        "id": "b93b2de25909867b",
+        "type": "api-call-service",
+        "z": "e2ce48a0f1cc65ac",
+        "name": "Woonkamer mid",
+        "server": "c5f56a3a.f3f838",
+        "version": 5,
+        "debugenabled": false,
+        "domain": "scene",
+        "service": "turn_on",
+        "areaId": [
+            "f003303ef40d4f74a22d0ac43952a198"
+        ],
+        "deviceId": [],
+        "entityId": [
+            "scene.woonkamer_dim"
+        ],
+        "data": "",
+        "dataType": "jsonata",
+        "mergeContext": "",
+        "mustacheAltTags": false,
+        "outputProperties": [],
+        "queue": "none",
+        "x": 780,
+        "y": 420,
+        "wires": [
+            []
+        ]
+    },
+    {
+        "id": "c5f56a3a.f3f838",
+        "type": "server",
+        "name": "Home Assistant",
+        "version": 5,
+        "addon": true,
+        "rejectUnauthorizedCerts": true,
+        "ha_boolean": "y|yes|true|on|home|open",
+        "connectionDelay": true,
+        "cacheJson": true,
+        "heartbeat": false,
+        "heartbeatInterval": "30",
+        "areaSelector": "friendlyName",
+        "deviceSelector": "friendlyName",
+        "entitySelector": "friendlyName",
+        "statusSeparator": "at: ",
+        "statusYear": "hidden",
+        "statusMonth": "short",
+        "statusDay": "numeric",
+        "statusHourCycle": "h23",
+        "statusTimeFormat": "h:m",
+        "enableGlobalContextStore": true
+    },
+    {
+        "id": "bbc4284780ea4146",
+        "type": "tab",
+        "label": "Button+ modes",
+        "disabled": false,
+        "info": "",
+        "env": []
+    },
+    {
+        "id": "791cd6a5c204cc2f",
+        "type": "subflow:e2ce48a0f1cc65ac",
+        "z": "bbc4284780ea4146",
+        "name": "Verlichting",
+        "x": 610,
+        "y": 180,
+        "wires": [
+            [],
+            [],
+            []
+        ]
+    },
+    {
+        "id": "d886aea62c470a8f",
+        "type": "subflow:6b88b4fda81a741c",
+        "z": "bbc4284780ea4146",
+        "name": "Muziek",
+        "x": 600,
+        "y": 240,
+        "wires": [
+            [],
+            [],
+            []
+        ]
+    },
+    {
+        "id": "89726a6b8d593340",
+        "type": "debug",
+        "z": "bbc4284780ea4146",
+        "name": "debug 16",
+        "active": true,
+        "tosidebar": true,
+        "console": false,
+        "tostatus": false,
+        "complete": "true",
+        "targetType": "full",
+        "statusVal": "",
+        "statusType": "auto",
+        "x": 620,
+        "y": 60,
+        "wires": []
+    },
+    {
+        "id": "5a57757bd02eecd3",
+        "type": "change",
+        "z": "bbc4284780ea4146",
+        "name": "",
+        "rules": [
+            {
+                "t": "set",
+                "p": "page",
+                "pt": "msg",
+                "to": "change",
+                "tot": "str"
+            },
+            {
+                "t": "set",
+                "p": "btn_click",
+                "pt": "msg",
+                "to": "",
+                "tot": "str"
+            },
+            {
+                "t": "set",
+                "p": "action_type",
+                "pt": "msg",
+                "to": "",
+                "tot": "str"
+            }
+        ],
+        "action": "",
+        "property": "",
+        "from": "",
+        "to": "",
+        "reg": false,
+        "x": 880,
+        "y": 120,
+        "wires": [
+            [
+                "5106d277bcf976aa"
+            ]
+        ]
+    },
+    {
+        "id": "c5c9d91309682db1",
+        "type": "subflow:3f278483a074ca1c",
+        "z": "bbc4284780ea4146",
+        "name": "Overdag",
+        "x": 600,
+        "y": 300,
+        "wires": [
+            [],
+            [],
+            []
+        ]
+    },
+    {
+        "id": "b5071d75c23ccfef",
+        "type": "switch",
+        "z": "bbc4284780ea4146",
+        "name": "",
+        "property": "page",
+        "propertyType": "msg",
+        "rules": [
+            {
+                "t": "eq",
+                "v": "main",
+                "vt": "str"
+            },
+            {
+                "t": "eq",
+                "v": "avond",
+                "vt": "str"
+            },
+            {
+                "t": "eq",
+                "v": "muziek",
+                "vt": "str"
+            },
+            {
+                "t": "eq",
+                "v": "overdag",
+                "vt": "str"
+            }
+        ],
+        "checkall": "true",
+        "repair": false,
+        "outputs": 4,
+        "x": 410,
+        "y": 220,
+        "wires": [
+            [
+                "15858f44f9fc05d3"
+            ],
+            [
+                "791cd6a5c204cc2f"
+            ],
+            [
+                "d886aea62c470a8f"
+            ],
+            [
+                "c5c9d91309682db1"
+            ]
+        ]
+    },
+    {
+        "id": "5106d277bcf976aa",
+        "type": "link out",
+        "z": "bbc4284780ea4146",
+        "name": "Link change menu",
+        "mode": "link",
+        "links": [
+            "03cb9248584c2950",
+            "b36509f9f438b121"
+        ],
+        "x": 1035,
+        "y": 120,
+        "wires": []
+    },
+    {
+        "id": "03cb9248584c2950",
+        "type": "link in",
+        "z": "bbc4284780ea4146",
+        "name": "Link change menu",
+        "links": [
+            "5106d277bcf976aa"
+        ],
+        "x": 255,
+        "y": 720,
+        "wires": [
+            [
+                "6d3807ac20f29c76"
+            ]
+        ]
+    },
+    {
+        "id": "ce6c6f8a40d28d94",
+        "type": "debug",
+        "z": "bbc4284780ea4146",
+        "name": "debug 19",
+        "active": true,
+        "tosidebar": true,
+        "console": false,
+        "tostatus": false,
+        "complete": "true",
+        "targetType": "full",
+        "statusVal": "",
+        "statusType": "auto",
+        "x": 1640,
+        "y": 1200,
+        "wires": []
+    },
+    {
+        "id": "15439787f889c4bc",
+        "type": "http request",
+        "z": "bbc4284780ea4146",
+        "name": "Post JSON",
+        "method": "POST",
+        "ret": "txt",
+        "paytoqs": "body",
+        "url": "",
+        "tls": "",
+        "persist": true,
+        "proxy": "",
+        "insecureHTTPParser": false,
+        "authType": "",
+        "senderr": false,
+        "headers": [
+            {
+                "keyType": "Content-Type",
+                "keyValue": "",
+                "valueType": "other",
+                "valueValue": "application/json"
+            }
+        ],
+        "x": 690,
+        "y": 480,
+        "wires": [
+            []
+        ]
+    },
+    {
+        "id": "d7cf955dedc23afe",
+        "type": "change",
+        "z": "bbc4284780ea4146",
+        "name": "",
+        "rules": [
+            {
+                "t": "set",
+                "p": "url",
+                "pt": "msg",
+                "to": "http://192.168.1.81/configsave",
+                "tot": "str"
+            }
+        ],
+        "action": "",
+        "property": "",
+        "from": "",
+        "to": "",
+        "reg": false,
+        "x": 510,
+        "y": 480,
+        "wires": [
+            [
+                "15439787f889c4bc"
+            ]
+        ]
+    },
+    {
+        "id": "814c151fd61b1c16",
+        "type": "function",
+        "z": "bbc4284780ea4146",
+        "name": "Assemble json object",
+        "func": "// default config\nvar configJSON = '{\"info\":{\"id\":\"btn_45a424\",\"mac\":\"F4:12:FA:45:A4:24\",\"ipaddress\":\"192.168.1.81\",\"firmware\":\"1.07\",\"largedisplay\":0,\"connectors\":[{\"id\":0,\"type\":2},{\"id\":1,\"type\":1},{\"id\":2,\"type\":1},{\"id\":3,\"type\":1}],\"sensors\":[{\"sensorid\":1,\"description\":\"Sensirion STS35 Temperature Sensor\"}]},\"core\":{\"name\":\"btn_45a424\",\"location\":\"Room 1\",\"autobackup\":true,\"brightnesslargedisplay\":\"61\",\"brightnessminidisplay\":50,\"ledcolorfront\":0,\"ledcolorwall\":0,\"color\":0},\"mqttbuttons\":[{\"id\":0,\"label\":\"0\",\"toplabel\":\" 0\",\"ledcolorfront\":0,\"ledcolorwall\":0,\"topics\":[{\"brokerid\":\"ha\",\"topic\":\"buttonplus/wk1/button/0/state\",\"payload\":\"0\",\"eventtype\":0},{\"brokerid\":\"ha\",\"topic\":\"buttonplus/wk1/button/0/longpress\",\"payload\":\"0\",\"eventtype\":1}]},{\"id\":1,\"label\":\"1\",\"toplabel\":\"1\",\"ledcolorfront\":0,\"ledcolorwall\":0,\"topics\":[{\"brokerid\":\"ha\",\"topic\":\"buttonplus/wk1/button/1/state\",\"payload\":\"1\",\"eventtype\":0},{\"brokerid\":\"ha\",\"topic\":\"buttonplus/wk1/button/1/longpress\",\"payload\":\"1\",\"eventtype\":1}]},{\"id\":2,\"label\":\"1\",\"toplabel\":\"2\",\"ledcolorfront\":0,\"ledcolorwall\":0,\"topics\":[{\"brokerid\":\"ha\",\"topic\":\"buttonplus/wk1/button/2/state\",\"payload\":\"2\",\"eventtype\":0},{\"brokerid\":\"ha\",\"topic\":\"buttonplus/wk1/button/2/longpress\",\"payload\":\"2\",\"eventtype\":1},{\"brokerid\":\"ha\",\"topic\":\"buttonplus/wk1/button/2/label\",\"payload\":\"\",\"eventtype\":11},{\"brokerid\":\"ha\",\"topic\":\"buttonplus/wk1/button/2/toplabel\",\"payload\":\"\",\"eventtype\":12},{\"brokerid\":\"ha\",\"topic\":\"buttonplus/wk1/button/2/ledrgb\",\"payload\":\"\",\"eventtype\":13},{\"brokerid\":\"ha\",\"topic\":\"buttonplus/wk1/button/2/led\",\"payload\":\"on\",\"eventtype\":14}]},{\"id\":3,\"label\":\"Play/Pause\",\"toplabel\":\"3\",\"ledcolorfront\":0,\"ledcolorwall\":0,\"topics\":[{\"brokerid\":\"ha\",\"topic\":\"buttonplus/wk1/button/3/state\",\"payload\":\"3\",\"eventtype\":0},{\"brokerid\":\"ha\",\"topic\":\"buttonplus/wk1/button/3/longpress\",\"payload\":\"3\",\"eventtype\":1},{\"brokerid\":\"ha\",\"topic\":\"buttonplus/wk1/button/3/label\",\"payload\":\"\",\"eventtype\":11},{\"brokerid\":\"ha\",\"topic\":\"buttonplus/wk1/button/3/toplabel\",\"payload\":\"\",\"eventtype\":12},{\"brokerid\":\"ha\",\"topic\":\"buttonplus/wk1/button/3/ledrgb\",\"payload\":\"\",\"eventtype\":13},{\"brokerid\":\"ha\",\"topic\":\"buttonplus/wk1/button/3/led\",\"payload\":\"on\",\"eventtype\":14}]},{\"id\":4,\"label\":\"Previous\",\"toplabel\":\"4\",\"ledcolorfront\":0,\"ledcolorwall\":0,\"topics\":[{\"brokerid\":\"ha\",\"topic\":\"buttonplus/wk1/button/4/state\",\"payload\":\"4\",\"eventtype\":0},{\"brokerid\":\"ha\",\"topic\":\"buttonplus/wk1/button/4/longpress\",\"payload\":\"4\",\"eventtype\":1},{\"brokerid\":\"ha\",\"topic\":\"buttonplus/wk1/button/4/label\",\"payload\":\"\",\"eventtype\":11},{\"brokerid\":\"ha\",\"topic\":\"buttonplus/wk1/button/4/toplabel\",\"payload\":\"\",\"eventtype\":12},{\"brokerid\":\"ha\",\"topic\":\"buttonplus/wk1/button/4/ledrgb\",\"payload\":\"\",\"eventtype\":13},{\"brokerid\":\"ha\",\"topic\":\"buttonplus/wk1/button/4/led\",\"payload\":\"on\",\"eventtype\":14}]},{\"id\":5,\"label\":\"Next\",\"toplabel\":\"5\",\"ledcolorfront\":0,\"ledcolorwall\":0,\"topics\":[{\"brokerid\":\"ha\",\"topic\":\"buttonplus/wk1/button/5/state\",\"payload\":\"5\",\"eventtype\":0},{\"brokerid\":\"ha\",\"topic\":\"buttonplus/wk1/button/5/longpress\",\"payload\":\"5\",\"eventtype\":1},{\"brokerid\":\"ha\",\"topic\":\"buttonplus/wk1/button/5/label\",\"payload\":\"\",\"eventtype\":11},{\"brokerid\":\"ha\",\"topic\":\"buttonplus/wk1/button/5/toplabel\",\"payload\":\"\",\"eventtype\":12},{\"brokerid\":\"ha\",\"topic\":\"buttonplus/wk1/button/5/ledrgb\",\"payload\":\"\",\"eventtype\":13},{\"brokerid\":\"ha\",\"topic\":\"buttonplus/wk1/button/5/led\",\"payload\":\"on\",\"eventtype\":14}]},{\"id\":6,\"label\":\"-\",\"toplabel\":\"6\",\"ledcolorfront\":0,\"ledcolorwall\":0,\"topics\":[{\"brokerid\":\"ha\",\"topic\":\"buttonplus/wk1/button/6/state\",\"payload\":\"6\",\"eventtype\":0},{\"brokerid\":\"ha\",\"topic\":\"buttonplus/wk1/button/6/longpress\",\"payload\":\"6\",\"eventtype\":1},{\"brokerid\":\"ha\",\"topic\":\"buttonplus/wk1/button/6/label\",\"payload\":\"\",\"eventtype\":11},{\"brokerid\":\"ha\",\"topic\":\"buttonplus/wk1/button/6/toplabel\",\"payload\":\"\",\"eventtype\":12},{\"brokerid\":\"ha\",\"topic\":\"buttonplus/wk1/button/6/ledrgb\",\"payload\":\"\",\"eventtype\":13},{\"brokerid\":\"ha\",\"topic\":\"buttonplus/wk1/button/6/led\",\"payload\":\"on\",\"eventtype\":14}]},{\"id\":7,\"label\":\"+\",\"toplabel\":\"7\",\"ledcolorfront\":0,\"ledcolorwall\":0,\"topics\":[{\"brokerid\":\"ha\",\"topic\":\"buttonplus/wk1/button/7/state\",\"payload\":\"7\",\"eventtype\":0},{\"brokerid\":\"ha\",\"topic\":\"buttonplus/wk1/button/7/longpress\",\"payload\":\"7\",\"eventtype\":1},{\"brokerid\":\"ha\",\"topic\":\"buttonplus/wk1/button/7/label\",\"payload\":\"\",\"eventtype\":11},{\"brokerid\":\"ha\",\"topic\":\"buttonplus/wk1/button/7/toplabel\",\"payload\":\"\",\"eventtype\":12},{\"brokerid\":\"ha\",\"topic\":\"buttonplus/wk1/button/7/ledrgb\",\"payload\":\"\",\"eventtype\":13},{\"brokerid\":\"ha\",\"topic\":\"buttonplus/wk1/button/7/led\",\"payload\":\"on\",\"eventtype\":14}]}],\"mqttdisplays\":[{\"x\":1,\"y\":1,\"fontsize\":2,\"align\":8,\"width\":25,\"label\":\"Dit is een label\",\"unit\":\"°C\",\"round\":1,\"topics\":[{\"brokerid\":\"ha\",\"topic\":\"buttonplus/wk1/display/1/value\",\"payload\":\"\",\"eventtype\":15},{\"brokerid\":\"ha\",\"topic\":\"buttonplus/wk1/display/1/label\",\"payload\":\"\",\"eventtype\":16},{\"brokerid\":\"ha\",\"topic\":\"buttonplus/wk1/display/1/uom\",\"payload\":\"\",\"eventtype\":17}]},{\"x\":30,\"y\":1,\"fontsize\":2,\"align\":0,\"width\":25,\"label\":\"Dit is een label2\",\"unit\":\"°C\",\"round\":0,\"topics\":[{\"brokerid\":\"ha\",\"topic\":\"buttonplus/wk1/display/2/value\",\"payload\":\"\",\"eventtype\":15},{\"brokerid\":\"ha\",\"topic\":\"buttonplus/wk1/display/2/label\",\"payload\":\"\",\"eventtype\":16},{\"brokerid\":\"ha\",\"topic\":\"buttonplus/wk1/display/2/uom\",\"payload\":\"\",\"eventtype\":17}]},{\"x\":0,\"y\":50,\"fontsize\":2,\"align\":8,\"width\":50,\"label\":\"Temperatuur\",\"unit\":\"\",\"round\":0,\"topics\":[{\"brokerid\":\"ha\",\"topic\":\"buttonplus/wk1/display/3/value\",\"payload\":\"\",\"eventtype\":15},{\"brokerid\":\"ha\",\"topic\":\"buttonplus/wk1/display/3/label\",\"payload\":\"\",\"eventtype\":16},{\"brokerid\":\"ha\",\"topic\":\"buttonplus/wk1/display/3/uom\",\"payload\":\"\",\"eventtype\":17}]},{\"x\":0,\"y\":20,\"fontsize\":1,\"align\":0,\"width\":100,\"label\":\"Dit is een label2\",\"unit\":\"°CC\",\"round\":0,\"topics\":[{\"brokerid\":\"ha\",\"topic\":\"buttonplus/wk1/display/4/value\",\"payload\":\"\",\"eventtype\":15},{\"brokerid\":\"ha\",\"topic\":\"buttonplus/wk1/display/4/label\",\"payload\":\"\",\"eventtype\":16},{\"brokerid\":\"ha\",\"topic\":\"buttonplus/wk1/display/4/uom\",\"payload\":\"\",\"eventtype\":17}]},{\"x\":70,\"y\":72,\"fontsize\":1,\"align\":0,\"width\":30,\"label\":\"Menu\",\"unit\":\"\",\"round\":0,\"topics\":[{\"brokerid\":\"ha\",\"topic\":\"buttonplus/wk1/display/5/value\",\"payload\":\"\",\"eventtype\":15},{\"brokerid\":\"ha\",\"topic\":\"buttonplus/wk1/display/5/label\",\"payload\":\"\",\"eventtype\":16},{\"brokerid\":\"ha\",\"topic\":\"buttonplus/wk1/display/5/uom\",\"payload\":\"\",\"eventtype\":17}]}],\"mqttbrokers\":[{\"brokerid\":\"buttonplus\",\"url\":\"mqtt://mqtt.button.plus\",\"port\":0,\"wsport\":0,\"username\":\"\",\"password\":\"\"},{\"brokerid\":\"ha\",\"url\":\"mqtt://192.168.1.7\",\"port\":1883,\"wsport\":0,\"username\":\"mqtt\",\"password\":\"mqtt\"}],\"mqttsensors\":[{\"sensorid\":1,\"topic\":{\"brokerid\":\"buttonplus\",\"topic\":\"button/btn_45a424/temperature\",\"payload\":\"\",\"eventtype\":18},\"interval\":10}]}'\nmsg.payload = configJSON;\nreturn msg;",
+        "outputs": 1,
+        "timeout": 0,
+        "noerr": 0,
+        "initialize": "",
+        "finalize": "",
+        "libs": [],
+        "x": 300,
+        "y": 480,
+        "wires": [
+            [
+                "d7cf955dedc23afe"
+            ]
+        ]
+    },
+    {
+        "id": "fb3a2727b131f08a",
+        "type": "inject",
+        "z": "bbc4284780ea4146",
+        "name": "",
+        "props": [
+            {
+                "p": "payload"
+            },
+            {
+                "p": "topic",
+                "vt": "str"
+            }
+        ],
+        "repeat": "",
+        "crontab": "",
+        "once": false,
+        "onceDelay": 0.1,
+        "topic": "",
+        "payload": "",
+        "payloadType": "date",
+        "x": 120,
+        "y": 480,
+        "wires": [
+            [
+                "814c151fd61b1c16"
+            ]
+        ]
+    },
+    {
+        "id": "a028aca5274eb278",
+        "type": "comment",
+        "z": "bbc4284780ea4146",
+        "name": "Default config",
+        "info": "",
+        "x": 130,
+        "y": 420,
+        "wires": []
+    },
+    {
+        "id": "a15704fb6b2ed516",
+        "type": "comment",
+        "z": "bbc4284780ea4146",
+        "name": "Splits based on page",
+        "info": "",
+        "x": 400,
+        "y": 280,
+        "wires": []
+    },
+    {
+        "id": "84702cc7d5cf9982",
+        "type": "comment",
+        "z": "bbc4284780ea4146",
+        "name": "Subscription to button MQTT topics",
+        "info": "",
+        "x": 160,
+        "y": 60,
+        "wires": []
+    },
+    {
+        "id": "63458f075f671caa",
+        "type": "server-state-changed",
+        "z": "bbc4284780ea4146",
+        "name": "HA Input Select",
+        "server": "c5f56a3a.f3f838",
+        "version": 5,
+        "outputs": 1,
+        "exposeAsEntityConfig": "",
+        "entityId": "input_select.buttonplus_wk1_menuselector",
+        "entityIdType": "exact",
+        "outputInitially": false,
+        "stateType": "str",
+        "ifState": "",
+        "ifStateType": "str",
+        "ifStateOperator": "is",
+        "outputOnlyOnStateChange": true,
+        "for": "0",
+        "forType": "num",
+        "forUnits": "minutes",
+        "ignorePrevStateNull": false,
+        "ignorePrevStateUnknown": false,
+        "ignorePrevStateUnavailable": false,
+        "ignoreCurrentStateUnknown": false,
+        "ignoreCurrentStateUnavailable": false,
+        "outputProperties": [
+            {
+                "property": "page",
+                "propertyType": "msg",
+                "value": "",
+                "valueType": "entityState"
+            },
+            {
+                "property": "data",
+                "propertyType": "msg",
+                "value": "",
+                "valueType": "eventData"
+            },
+            {
+                "property": "topic",
+                "propertyType": "msg",
+                "value": "",
+                "valueType": "triggerId"
+            }
+        ],
+        "x": 200,
+        "y": 820,
+        "wires": [
+            [
+                "6d3807ac20f29c76"
+            ]
+        ]
+    },
+    {
+        "id": "6d3807ac20f29c76",
+        "type": "state-machine",
+        "z": "bbc4284780ea4146",
+        "name": "Pages",
+        "triggerProperty": "page",
+        "triggerPropertyType": "msg",
+        "stateProperty": "page",
+        "statePropertyType": "msg",
+        "initialDelay": "0",
+        "persistOnReload": true,
+        "outputStateChangeOnly": true,
+        "throwException": false,
+        "states": [
+            "avond",
+            "muziek",
+            "overdag"
+        ],
+        "transitions": [
+            {
+                "name": "change",
+                "from": "avond",
+                "to": "muziek"
+            },
+            {
+                "name": "change",
+                "from": "muziek",
+                "to": "overdag"
+            },
+            {
+                "name": "change",
+                "from": "overdag",
+                "to": "avond"
+            },
+            {
+                "name": "avond",
+                "from": "*",
+                "to": "avond"
+            },
+            {
+                "name": "overdag",
+                "from": "*",
+                "to": "overdag"
+            },
+            {
+                "name": "muziek",
+                "from": "*",
+                "to": "muziek"
+            }
+        ],
+        "x": 470,
+        "y": 880,
+        "wires": [
+            [
+                "c94b82af6ba988a6"
+            ]
+        ]
+    },
+    {
+        "id": "a086e75b78cbf24f",
+        "type": "inject",
+        "z": "bbc4284780ea4146",
+        "name": "page: change",
+        "props": [
+            {
+                "p": "page",
+                "v": "change",
+                "vt": "str"
+            }
+        ],
+        "repeat": "",
+        "crontab": "",
+        "once": false,
+        "onceDelay": 0.1,
+        "topic": "",
+        "x": 210,
+        "y": 880,
+        "wires": [
+            [
+                "6d3807ac20f29c76"
+            ]
+        ]
+    },
+    {
+        "id": "0f2cdb45b427cadd",
+        "type": "inject",
+        "z": "bbc4284780ea4146",
+        "name": "page: avond",
+        "props": [
+            {
+                "p": "page",
+                "v": "avond",
+                "vt": "str"
+            }
+        ],
+        "repeat": "",
+        "crontab": "",
+        "once": false,
+        "onceDelay": 0.1,
+        "topic": "",
+        "x": 210,
+        "y": 920,
+        "wires": [
+            [
+                "6d3807ac20f29c76"
+            ]
+        ]
+    },
+    {
+        "id": "73c7d6fba7621f74",
+        "type": "inject",
+        "z": "bbc4284780ea4146",
+        "name": "page: muziek",
+        "props": [
+            {
+                "p": "page",
+                "v": "muziek",
+                "vt": "str"
+            }
+        ],
+        "repeat": "",
+        "crontab": "",
+        "once": false,
+        "onceDelay": 0.1,
+        "topic": "",
+        "x": 210,
+        "y": 960,
+        "wires": [
+            [
+                "6d3807ac20f29c76"
+            ]
+        ]
+    },
+    {
+        "id": "a985c32762b7f802",
+        "type": "inject",
+        "z": "bbc4284780ea4146",
+        "name": "page: overdag",
+        "props": [
+            {
+                "p": "page",
+                "v": "overdag",
+                "vt": "str"
+            }
+        ],
+        "repeat": "",
+        "crontab": "",
+        "once": false,
+        "onceDelay": 0.1,
+        "topic": "",
+        "x": 210,
+        "y": 1000,
+        "wires": [
+            [
+                "6d3807ac20f29c76"
+            ]
+        ]
+    },
+    {
+        "id": "c94b82af6ba988a6",
+        "type": "change",
+        "z": "bbc4284780ea4146",
+        "name": "pagebutton",
+        "rules": [
+            {
+                "t": "set",
+                "p": "topic",
+                "pt": "msg",
+                "to": "buttonplus/wk1/button/",
+                "tot": "str"
+            },
+            {
+                "t": "change",
+                "p": "page",
+                "pt": "msg",
+                "from": "change",
+                "fromt": "str",
+                "to": "",
+                "tot": "str"
+            },
+            {
+                "t": "set",
+                "p": "pagebutton.0",
+                "pt": "msg",
+                "to": "main",
+                "tot": "str"
+            },
+            {
+                "t": "set",
+                "p": "pagebutton.1",
+                "pt": "msg",
+                "to": "main",
+                "tot": "str"
+            },
+            {
+                "t": "set",
+                "p": "pagebutton.2",
+                "pt": "msg",
+                "to": "main",
+                "tot": "str"
+            },
+            {
+                "t": "set",
+                "p": "pagebutton.3",
+                "pt": "msg",
+                "to": "page",
+                "tot": "msg"
+            },
+            {
+                "t": "set",
+                "p": "pagebutton.4",
+                "pt": "msg",
+                "to": "page",
+                "tot": "msg"
+            },
+            {
+                "t": "set",
+                "p": "pagebutton.5",
+                "pt": "msg",
+                "to": "page",
+                "tot": "msg"
+            },
+            {
+                "t": "set",
+                "p": "pagebutton.6",
+                "pt": "msg",
+                "to": "page",
+                "tot": "msg"
+            },
+            {
+                "t": "set",
+                "p": "pagebutton.7",
+                "pt": "msg",
+                "to": "page",
+                "tot": "msg"
+            }
+        ],
+        "action": "",
+        "property": "",
+        "from": "",
+        "to": "",
+        "reg": false,
+        "x": 470,
+        "y": 1040,
+        "wires": [
+            [
+                "8c9be970874aeae6",
+                "fdb5418b5a49e3bb",
+                "6a443854cee65d0e"
+            ]
+        ]
+    },
+    {
+        "id": "8c9be970874aeae6",
+        "type": "function",
+        "z": "bbc4284780ea4146",
+        "name": "mqttbuttons JSON",
+        "func": "context.mqttbuttonsarray = [];\nvar topics = [];\n\nlet buttons = Object.values(msg.pagebutton);\n\nbuttons.forEach((val, index) => {\n  var mqttbuttons_temp = {};\n  mqttbuttons_temp['id'] = index;\n  mqttbuttons_temp['label'] = \" \";\n  mqttbuttons_temp['toplabel'] = \" \";\n  mqttbuttons_temp['ledcolorfront'] = 0;\n  mqttbuttons_temp['ledcolorwall'] = 0;\n  if (index == 0 || index == 1) {\n    topics = [\n      {\n        \"brokerid\": \"ha\",\n        \"topic\": msg.topic  + val + \"/\" + index + \"/state\",\n        \"payload\": index.toString(),\n        \"eventtype\": 0\n      },\n      {\n        \"brokerid\": \"ha\",\n        \"topic\": msg.topic + val + \"/\" + index + \"/longpress\",\n        \"payload\": index.toString(),\n        \"eventtype\": 1\n      }]\n  } else {\n    topics = [\n      {\n        \"brokerid\": \"ha\",\n        \"topic\": msg.topic + val + \"/\" + index + \"/state\",\n        \"payload\": index.toString(),\n        \"eventtype\": 0\n      }\n      , {\n        \"brokerid\": \"ha\",\n        \"topic\": msg.topic + val + \"/\" + index + \"/longpress\",\n        \"payload\": index.toString(),\n        \"eventtype\": 1\n      }\n      // // { \"brokerid\": \"ha\",\n      // //   \"topic\": \"buttonplus/wk1/button/\" + buttons[i] + \"/release\",\n      // //   \"payload\": buttons[i].toString(),\n      // //   \"eventtype\": 2 },\n      // ,{ \"brokerid\": \"ha\",\n      //   \"topic\": \"buttonplus/wk1/button/\" + buttons[i] + \"/ledblue\",\n      //   \"payload\": \"on\",\n      //   \"eventtype\": 8 }\n      // ,{ \"brokerid\": \"ha\",\n      //   \"topic\": \"buttonplus/wk1/button/\" + buttons[i] + \"/ledred\",\n      //   \"payload\": \"on\",\n      //   \"eventtype\": 9 }\n      // ,{ \"brokerid\": \"ha\",\n      //   \"topic\": \"buttonplus/wk1/button/\" + buttons[i] + \"/ledgreen\",\n      //   \"payload\": \"on\",\n      //   \"eventtype\": 10 }\n      , {\n        \"brokerid\": \"ha\",\n        \"topic\": msg.topic + val + \"/\" + index + \"/label\",\n        // \"payload\": \"\",\n        \"eventtype\": 11\n      }\n      , {\n        \"brokerid\": \"ha\",\n        \"topic\": msg.topic + val + \"/\" + index + \"/toplabel\",\n        // \"payload\": \"\",\n        \"eventtype\": 12\n      }\n\n      // ,{ \"brokerid\": \"ha\",\n      //   \"topic\": \"buttonplus/wk1/button/\" + buttons[i] + \"/led\",\n      //   \"payload\": \"on\",\n      //   \"eventtype\": 14 }\n\n      , {\n        \"brokerid\": \"ha\",\n        \"topic\": msg.topic + val + \"/\" + index + \"/ledrgb\",\n        \"payload\": \"0\",\n        // .toString()\n        \"eventtype\": 13\n      }\n    ]\n  }\n\n  mqttbuttons_temp['topics'] = topics;\n  context.mqttbuttonsarray.push(mqttbuttons_temp);\n})\n\nmsg.mqttbuttons = context.mqttbuttonsarray;\n\n// Initialize displayitem JSON\nmsg.displayitem = [];\nreturn msg;",
+        "outputs": 1,
+        "timeout": 0,
+        "noerr": 0,
+        "initialize": "",
+        "finalize": "",
+        "libs": [],
+        "x": 730,
+        "y": 880,
+        "wires": [
+            [
+                "3188db217b8b6298"
+            ]
+        ]
+    },
+    {
+        "id": "cf2eb2efe29af8d0",
+        "type": "http request",
+        "z": "bbc4284780ea4146",
+        "name": "Post JSON",
+        "method": "POST",
+        "ret": "txt",
+        "paytoqs": "body",
+        "url": "",
+        "tls": "",
+        "persist": true,
+        "proxy": "",
+        "insecureHTTPParser": false,
+        "authType": "",
+        "senderr": false,
+        "headers": [
+            {
+                "keyType": "Content-Type",
+                "keyValue": "",
+                "valueType": "other",
+                "valueValue": "application/json"
+            }
+        ],
+        "x": 1650,
+        "y": 1160,
+        "wires": [
+            [
+                "ce6c6f8a40d28d94"
+            ]
+        ]
+    },
+    {
+        "id": "3eb17d954066e070",
+        "type": "function",
+        "z": "bbc4284780ea4146",
+        "name": "Set headers",
+        "func": "msg.url='http://192.168.1.81/configsave'\n\nmsg.headers = {};\nmsg.headers[\"Accept\"] = 'application/json';\nmsg.headers[\"Accept-Encoding\"] = 'gzip, deflate, br';\nmsg.headers[\"json\"] = true;\nreturn msg;\n",
+        "outputs": 1,
+        "timeout": 0,
+        "noerr": 0,
+        "initialize": "",
+        "finalize": "",
+        "libs": [],
+        "x": 1650,
+        "y": 1120,
+        "wires": [
+            [
+                "cf2eb2efe29af8d0"
+            ]
+        ],
+        "icon": "font-awesome/fa-lock"
+    },
+    {
+        "id": "0e26ad4a81c8cec8",
+        "type": "function",
+        "z": "bbc4284780ea4146",
+        "name": "Assemble json object",
+        "func": "var configJSON = {};\nvar brightness = flow.get('brightness');\n\n// configJSON['info'] = '{ \"largedisplay\": 3, \"i2cs\": [],\"connectors\": [{\"id\": 3,\"type\": 2},{\"id\": 4,\"type\": 1}],\"sensors\": []}';\nconfigJSON['info'] = {\n    \"id\": \"wk1\",\n    \"mac\": \"F4:12:FA:45:A4:24\",\n    \"ipaddress\": \"192.168.1.81\",\n    \"firmware\": \"1.07\",\n    \"largedisplay\": 0,\n    \"connectors\": [\n        { \"id\": 0, \"type\": 2 },\n        { \"id\": 1, \"type\": 1 },\n        { \"id\": 2, \"type\": 1 },\n        { \"id\": 3, \"type\": 1 }\n    ],\n    \"sensors\": [\n        { \"sensorid\": 1, \"description\": \"Sensirion STS35 Temperature Sensor\" }\n    ]\n}\n\nconfigJSON['core'] = {\n    \"name\": \"wk1\",\n    \"location\": \"Woonkamer 1\",\n    \"autobackup\": true,\n    \"brightnesslargedisplay\": brightness,\n    \"brightnessminidisplay\": brightness,\n    \"ledcolorfront\": 0,\n    \"ledcolorwall\": 0,\n    \"color\": 0\n}\n\n\nconfigJSON['mqttbuttons'] = msg.mqttbuttons;\nconfigJSON['mqttdisplays'] = msg.displayitem;\n\n\nmsg.payload = configJSON;\nreturn msg;",
+        "outputs": 1,
+        "timeout": 0,
+        "noerr": 0,
+        "initialize": "",
+        "finalize": "",
+        "libs": [],
+        "x": 1320,
+        "y": 1120,
+        "wires": [
+            [
+                "3eb17d954066e070"
+            ]
+        ]
+    },
+    {
+        "id": "6476a339a624f9e9",
+        "type": "comment",
+        "z": "bbc4284780ea4146",
+        "name": "Update B+",
+        "info": "",
+        "x": 1620,
+        "y": 1080,
+        "wires": []
+    },
+    {
+        "id": "d40843311b88541a",
+        "type": "change",
+        "z": "bbc4284780ea4146",
+        "name": "draw Verlichting label",
+        "rules": [
+            {
+                "t": "set",
+                "p": "title",
+                "pt": "msg",
+                "to": "Avond",
+                "tot": "str"
+            },
+            {
+                "t": "set",
+                "p": "label.0",
+                "pt": "msg",
+                "to": "Slaapstand",
+                "tot": "str"
+            },
+            {
+                "t": "set",
+                "p": "label.1",
+                "pt": "msg",
+                "to": "Avond",
+                "tot": "str"
+            },
+            {
+                "t": "set",
+                "p": "label.2",
+                "pt": "msg",
+                "to": "",
+                "tot": "str"
+            },
+            {
+                "t": "set",
+                "p": "label.3",
+                "pt": "msg",
+                "to": "",
+                "tot": "str"
+            },
+            {
+                "t": "set",
+                "p": "label.4",
+                "pt": "msg",
+                "to": "Avond mid",
+                "tot": "str"
+            },
+            {
+                "t": "set",
+                "p": "label.5",
+                "pt": "msg",
+                "to": "Avond dim",
+                "tot": "str"
+            },
+            {
+                "t": "set",
+                "p": "label.6",
+                "pt": "msg",
+                "to": "Slaapstand",
+                "tot": "str"
+            },
+            {
+                "t": "set",
+                "p": "label.7",
+                "pt": "msg",
+                "to": "Avond vol",
+                "tot": "str"
+            },
+            {
+                "t": "set",
+                "p": "toplabel.0",
+                "pt": "msg",
+                "to": " ",
+                "tot": "str"
+            },
+            {
+                "t": "set",
+                "p": "toplabel.1",
+                "pt": "msg",
+                "to": "1",
+                "tot": "str"
+            },
+            {
+                "t": "set",
+                "p": "toplabel.2",
+                "pt": "msg",
+                "to": "",
+                "tot": "str"
+            },
+            {
+                "t": "set",
+                "p": "toplabel.3",
+                "pt": "msg",
+                "to": "",
+                "tot": "str"
+            },
+            {
+                "t": "set",
+                "p": "toplabel.4",
+                "pt": "msg",
+                "to": "Verlichting",
+                "tot": "str"
+            },
+            {
+                "t": "set",
+                "p": "toplabel.5",
+                "pt": "msg",
+                "to": "Verlichting",
+                "tot": "str"
+            },
+            {
+                "t": "set",
+                "p": "toplabel.6",
+                "pt": "msg",
+                "to": "Alles uit",
+                "tot": "str"
+            },
+            {
+                "t": "set",
+                "p": "toplabel.7",
+                "pt": "msg",
+                "to": "Verlichting",
+                "tot": "str"
+            },
+            {
+                "t": "set",
+                "p": "ledrgb.0",
+                "pt": "msg",
+                "to": "0",
+                "tot": "num"
+            },
+            {
+                "t": "set",
+                "p": "ledrgb.1",
+                "pt": "msg",
+                "to": "0",
+                "tot": "num"
+            },
+            {
+                "t": "set",
+                "p": "ledrgb.2",
+                "pt": "msg",
+                "to": "0",
+                "tot": "num"
+            },
+            {
+                "t": "set",
+                "p": "ledrgb.3",
+                "pt": "msg",
+                "to": "0",
+                "tot": "num"
+            },
+            {
+                "t": "set",
+                "p": "ledrgb.4",
+                "pt": "msg",
+                "to": "0",
+                "tot": "num"
+            },
+            {
+                "t": "set",
+                "p": "ledrgb.5",
+                "pt": "msg",
+                "to": "0",
+                "tot": "num"
+            },
+            {
+                "t": "set",
+                "p": "ledrgb.6",
+                "pt": "msg",
+                "to": "0",
+                "tot": "num"
+            },
+            {
+                "t": "set",
+                "p": "ledrgb.7",
+                "pt": "msg",
+                "to": "0",
+                "tot": "num"
+            }
+        ],
+        "action": "",
+        "property": "",
+        "from": "",
+        "to": "",
+        "reg": false,
+        "x": 480,
+        "y": 1260,
+        "wires": [
+            [
+                "bb32a343824dc33b"
+            ]
+        ]
+    },
+    {
+        "id": "19db5d2c7a02a803",
+        "type": "change",
+        "z": "bbc4284780ea4146",
+        "name": "draw Muziek label",
+        "rules": [
+            {
+                "t": "set",
+                "p": "label.0",
+                "pt": "msg",
+                "to": "Slaapstand",
+                "tot": "str"
+            },
+            {
+                "t": "set",
+                "p": "label.1",
+                "pt": "msg",
+                "to": "Avond",
+                "tot": "str"
+            },
+            {
+                "t": "set",
+                "p": "label.2",
+                "pt": "msg",
+                "to": "",
+                "tot": "str"
+            },
+            {
+                "t": "set",
+                "p": "label.3",
+                "pt": "msg",
+                "to": "Play/Pause",
+                "tot": "str"
+            },
+            {
+                "t": "set",
+                "p": "label.4",
+                "pt": "msg",
+                "to": "Previous",
+                "tot": "str"
+            },
+            {
+                "t": "set",
+                "p": "label.5",
+                "pt": "msg",
+                "to": "Next",
+                "tot": "str"
+            },
+            {
+                "t": "set",
+                "p": "label.6",
+                "pt": "msg",
+                "to": "-",
+                "tot": "str"
+            },
+            {
+                "t": "set",
+                "p": "label.7",
+                "pt": "msg",
+                "to": "+",
+                "tot": "str"
+            },
+            {
+                "t": "set",
+                "p": "toplabel.0",
+                "pt": "msg",
+                "to": " ",
+                "tot": "str"
+            },
+            {
+                "t": "set",
+                "p": "toplabel.1",
+                "pt": "msg",
+                "to": "1",
+                "tot": "str"
+            },
+            {
+                "t": "set",
+                "p": "toplabel.2",
+                "pt": "msg",
+                "to": "",
+                "tot": "str"
+            },
+            {
+                "t": "set",
+                "p": "toplabel.3",
+                "pt": "msg",
+                "to": "",
+                "tot": "str"
+            },
+            {
+                "t": "set",
+                "p": "toplabel.4",
+                "pt": "msg",
+                "to": "",
+                "tot": "str"
+            },
+            {
+                "t": "set",
+                "p": "toplabel.5",
+                "pt": "msg",
+                "to": "",
+                "tot": "str"
+            },
+            {
+                "t": "set",
+                "p": "toplabel.6",
+                "pt": "msg",
+                "to": "Volume",
+                "tot": "str"
+            },
+            {
+                "t": "set",
+                "p": "toplabel.7",
+                "pt": "msg",
+                "to": "Volume",
+                "tot": "str"
+            },
+            {
+                "t": "set",
+                "p": "title",
+                "pt": "msg",
+                "to": "Muziek",
+                "tot": "str"
+            },
+            {
+                "t": "set",
+                "p": "ledrgb.0",
+                "pt": "msg",
+                "to": "0",
+                "tot": "num"
+            },
+            {
+                "t": "set",
+                "p": "ledrgb.1",
+                "pt": "msg",
+                "to": "0",
+                "tot": "num"
+            },
+            {
+                "t": "set",
+                "p": "ledrgb.2",
+                "pt": "msg",
+                "to": "0",
+                "tot": "num"
+            },
+            {
+                "t": "set",
+                "p": "ledrgb.3",
+                "pt": "msg",
+                "to": "0",
+                "tot": "num"
+            },
+            {
+                "t": "set",
+                "p": "ledrgb.4",
+                "pt": "msg",
+                "to": "0",
+                "tot": "num"
+            },
+            {
+                "t": "set",
+                "p": "ledrgb.5",
+                "pt": "msg",
+                "to": "0",
+                "tot": "num"
+            },
+            {
+                "t": "set",
+                "p": "ledrgb.6",
+                "pt": "msg",
+                "to": "0",
+                "tot": "num"
+            },
+            {
+                "t": "set",
+                "p": "ledrgb.7",
+                "pt": "msg",
+                "to": "0",
+                "tot": "num"
+            }
+        ],
+        "action": "",
+        "property": "",
+        "from": "",
+        "to": "",
+        "reg": false,
+        "x": 470,
+        "y": 1300,
+        "wires": [
+            [
+                "bb32a343824dc33b"
+            ]
+        ]
+    },
+    {
+        "id": "82bf5afba94b270d",
+        "type": "change",
+        "z": "bbc4284780ea4146",
+        "name": "draw Overdag label",
+        "rules": [
+            {
+                "t": "set",
+                "p": "title",
+                "pt": "msg",
+                "to": "Overdag",
+                "tot": "str"
+            },
+            {
+                "t": "set",
+                "p": "label.0",
+                "pt": "msg",
+                "to": "Slaapstand",
+                "tot": "str"
+            },
+            {
+                "t": "set",
+                "p": "label.1",
+                "pt": "msg",
+                "to": "o1",
+                "tot": "str"
+            },
+            {
+                "t": "set",
+                "p": "label.2",
+                "pt": "msg",
+                "to": "",
+                "tot": "str"
+            },
+            {
+                "t": "set",
+                "p": "label.3",
+                "pt": "msg",
+                "to": "",
+                "tot": "str"
+            },
+            {
+                "t": "set",
+                "p": "label.4",
+                "pt": "msg",
+                "to": "",
+                "tot": "str"
+            },
+            {
+                "t": "set",
+                "p": "label.5",
+                "pt": "msg",
+                "to": "Alles aan",
+                "tot": "str"
+            },
+            {
+                "t": "set",
+                "p": "label.6",
+                "pt": "msg",
+                "to": "Vertrekken",
+                "tot": "str"
+            },
+            {
+                "t": "set",
+                "p": "label.7",
+                "pt": "msg",
+                "to": "Ochtend",
+                "tot": "str"
+            },
+            {
+                "t": "set",
+                "p": "toplabel.0",
+                "pt": "msg",
+                "to": " ",
+                "tot": "str"
+            },
+            {
+                "t": "set",
+                "p": "toplabel.1",
+                "pt": "msg",
+                "to": "1",
+                "tot": "str"
+            },
+            {
+                "t": "set",
+                "p": "toplabel.2",
+                "pt": "msg",
+                "to": "",
+                "tot": "str"
+            },
+            {
+                "t": "set",
+                "p": "toplabel.3",
+                "pt": "msg",
+                "to": "",
+                "tot": "str"
+            },
+            {
+                "t": "set",
+                "p": "toplabel.4",
+                "pt": "msg",
+                "to": "",
+                "tot": "str"
+            },
+            {
+                "t": "set",
+                "p": "toplabel.5",
+                "pt": "msg",
+                "to": "Verlichting",
+                "tot": "str"
+            },
+            {
+                "t": "set",
+                "p": "toplabel.6",
+                "pt": "msg",
+                "to": "Alles uit",
+                "tot": "str"
+            },
+            {
+                "t": "set",
+                "p": "toplabel.7",
+                "pt": "msg",
+                "to": "Verlichting",
+                "tot": "str"
+            },
+            {
+                "t": "set",
+                "p": "ledrgb.0",
+                "pt": "msg",
+                "to": "0",
+                "tot": "num"
+            },
+            {
+                "t": "set",
+                "p": "ledrgb.1",
+                "pt": "msg",
+                "to": "0",
+                "tot": "num"
+            },
+            {
+                "t": "set",
+                "p": "ledrgb.2",
+                "pt": "msg",
+                "to": "0",
+                "tot": "num"
+            },
+            {
+                "t": "set",
+                "p": "ledrgb.3",
+                "pt": "msg",
+                "to": "0",
+                "tot": "num"
+            },
+            {
+                "t": "set",
+                "p": "ledrgb.4",
+                "pt": "msg",
+                "to": "0",
+                "tot": "num"
+            },
+            {
+                "t": "set",
+                "p": "ledrgb.5",
+                "pt": "msg",
+                "to": "0",
+                "tot": "num"
+            },
+            {
+                "t": "set",
+                "p": "ledrgb.6",
+                "pt": "msg",
+                "to": "0",
+                "tot": "num"
+            },
+            {
+                "t": "set",
+                "p": "ledrgb.7",
+                "pt": "msg",
+                "to": "0",
+                "tot": "num"
+            }
+        ],
+        "action": "",
+        "property": "",
+        "from": "",
+        "to": "",
+        "reg": false,
+        "x": 470,
+        "y": 1340,
+        "wires": [
+            [
+                "bb32a343824dc33b"
+            ]
+        ]
+    },
+    {
+        "id": "bb32a343824dc33b",
+        "type": "function",
+        "z": "bbc4284780ea4146",
+        "name": "prepare MQTT topics",
+        "func": "// Definition of sleep function\n// This prevents overloading of MQTT bus\nfunction sleep(ms) {\n    return new Promise((resolve) => {\n        setTimeout(resolve, ms);\n    });\n}\n\nvar page = msg.page+\"/\";\n\nfor (var i in msg.label){\n    var newMsg = {};\n    // send label\n    newMsg.payload = msg.label[i];\n    if (newMsg.payload == \"\") { newMsg.payload = \" \" }\n    newMsg.topic = msg.topic+page+i+\"/label\";\n    node.send(newMsg);\n    await sleep(20);\n\n    // send toplabel\n    newMsg.payload = msg.toplabel[i];\n    if (newMsg.payload == \"\") { newMsg.payload = \" \" }\n    newMsg.topic = msg.topic + page +i+\"/toplabel\";\n    node.send(newMsg);\n    await sleep(20);\n    // send led color\n    newMsg.payload = msg.ledrgb[i];\n    newMsg.topic = msg.topic + page +i+\"/ledrgb\";\n    node.send(newMsg);\n    await sleep(20);\n    // send led state\n    // newMsg.payload = msg.led[i];\n    // newMsg.topic = msg.topic + i + \"/led\";\n    // node.send(newMsg);\n}\n\nreturn null;",
+        "outputs": 1,
+        "timeout": 0,
+        "noerr": 0,
+        "initialize": "",
+        "finalize": "",
+        "libs": [],
+        "x": 740,
+        "y": 1300,
+        "wires": [
+            [
+                "0c40b3f89d4b7cbe"
+            ]
+        ]
+    },
+    {
+        "id": "0c40b3f89d4b7cbe",
+        "type": "mqtt out",
+        "z": "bbc4284780ea4146",
+        "name": "Update buttons",
+        "topic": "",
+        "qos": "2",
+        "retain": "true",
+        "respTopic": "",
+        "contentType": "",
+        "userProps": "",
+        "correl": "",
+        "expiry": "",
+        "broker": "e6dbd5fb3f32ec20",
+        "x": 960,
+        "y": 1300,
+        "wires": []
+    },
+    {
+        "id": "fdb5418b5a49e3bb",
+        "type": "switch",
+        "z": "bbc4284780ea4146",
+        "name": "",
+        "property": "page",
+        "propertyType": "msg",
+        "rules": [
+            {
+                "t": "eq",
+                "v": "avond",
+                "vt": "str"
+            },
+            {
+                "t": "eq",
+                "v": "muziek",
+                "vt": "str"
+            },
+            {
+                "t": "eq",
+                "v": "overdag",
+                "vt": "str"
+            }
+        ],
+        "checkall": "true",
+        "repair": false,
+        "outputs": 3,
+        "x": 250,
+        "y": 1300,
+        "wires": [
+            [
+                "d40843311b88541a"
+            ],
+            [
+                "19db5d2c7a02a803"
+            ],
+            [
+                "82bf5afba94b270d"
+            ]
+        ]
+    },
+    {
+        "id": "3188db217b8b6298",
+        "type": "function",
+        "z": "bbc4284780ea4146",
+        "name": "Displayitem 1",
+        "func": "//// Configuration of displayitem\n// assign unique number\nvar displayitem = 1;\n// assign to a page\nvar page = \"main\";\n// add characteristics\nvar x = 0;\nvar y = 0;\nvar fontsize = 3;\nvar width = 27;\nvar label = \"\";\nvar value = \"\";\nvar uom = \"°C\"\nvar round = 1;\nvar align = 0;\n\n// no config below this line\nvar newitem = {};\n\nnewitem = {\n    \"page\": page,\n    \"x\": x,\n    \"y\": y,\n    \"fontsize\": fontsize,\n    \"width\": width,\n    \"label\": label,\n    \"value\": value,\n    \"uom\": uom,\n    \"round\": round,\n    \"align\": align\n};\nmsg.displayitem[displayitem] = newitem;\nreturn msg;",
+        "outputs": 1,
+        "timeout": 0,
+        "noerr": 0,
+        "initialize": "",
+        "finalize": "",
+        "libs": [],
+        "x": 980,
+        "y": 880,
+        "wires": [
+            [
+                "86ed38097572038e"
+            ]
+        ]
+    },
+    {
+        "id": "86ed38097572038e",
+        "type": "function",
+        "z": "bbc4284780ea4146",
+        "name": "Displayitem 2",
+        "func": "//// Configuration of displayitem\n// assign unique number\nvar displayitem = 2;\n// assign to a page\nvar page = \"main\";\n// add characteristics\nvar x = 36;\nvar y = 0;\nvar fontsize = 3;\nvar width = 25;\nvar label = \"\";\nvar value = \"\";\nvar uom = \"°C\"\nvar round = 0;\nvar align = 0;\n\n// no config below this line\nvar newitem = {};\n\nnewitem = {\n    \"page\": page,\n    \"x\": x,\n    \"y\": y,\n    \"fontsize\": fontsize,\n    \"width\": width,\n    \"label\": label,\n    \"value\": value,\n    \"uom\": uom,\n    \"round\": round,\n    \"align\": align\n};\nmsg.displayitem[displayitem] = newitem;\n\n\nreturn msg;",
+        "outputs": 1,
+        "timeout": 0,
+        "noerr": 0,
+        "initialize": "",
+        "finalize": "",
+        "libs": [],
+        "x": 980,
+        "y": 920,
+        "wires": [
+            [
+                "65343ba3b7c732f7"
+            ]
+        ]
+    },
+    {
+        "id": "65343ba3b7c732f7",
+        "type": "function",
+        "z": "bbc4284780ea4146",
+        "name": "Displayitem 3",
+        "func": "//// Configuration of displayitem\n// assign unique number\nvar displayitem = 3;\n// assign to a page\nvar page = \"main\";\n// add characteristics\nvar x = 70;\nvar y = 0;\nvar fontsize = 3;\nvar width = 30;\nvar label = \"\";\nvar value = \"\";\nvar uom = \"°C\"\nvar round = 0;\nvar align = 0;\n\n// no config below this line\nvar newitem = {};\n\nnewitem = {\n    \"page\": page,\n    \"x\": x,\n    \"y\":y,\n    \"fontsize\": fontsize,\n    \"width\": width,\n    \"label\": label,\n    \"value\": value,\n    \"uom\": uom,\n    \"round\": round,\n    \"align\": align\n};\nmsg.displayitem[displayitem] = newitem;\n\n\nreturn msg;",
+        "outputs": 1,
+        "timeout": 0,
+        "noerr": 0,
+        "initialize": "",
+        "finalize": "",
+        "libs": [],
+        "x": 980,
+        "y": 960,
+        "wires": [
+            [
+                "fc6d1e231f9bdac4"
+            ]
+        ]
+    },
+    {
+        "id": "3ced4d268c0b687d",
+        "type": "function",
+        "z": "bbc4284780ea4146",
+        "name": "add topics",
+        "func": "var displayitem = msg.displayitem;\n\n// Walk through all display items and add required JSON\nfor (var i in displayitem) {\n    displayitem[i]['topics'] = [{\n        \"brokerid\": \"ha\",\n        \"topic\": \"buttonplus/wk1/display/\" + displayitem[i]['page'] + \"/\" + i + \"/value\",\n        \"eventtype\": 15\n    }, {\n        \"brokerid\": \"ha\", \"topic\": \"buttonplus/wk1/display/\" + displayitem[i]['page'] + \"/\" + i + \"/label\",\n        \"eventtype\": 16\n    }, {\n        \"brokerid\": \"ha\", \"topic\": \"buttonplus/wk1/display/\" + displayitem[i]['page'] + \"/\" + i + \"/uom\",\n        \"eventtype\": 17\n    }\n    ]\n};\n\n// Cleanup array\nvar newarray = [];\nvar j = 0;\nfor (let i = 0; i < displayitem.length; i++) {\n    if (displayitem[i] !== undefined) {\n        newarray[j] = displayitem[i];\n        j = j + 1;\n    }\n}\n\nmsg.displayitem = newarray;\n\n\nreturn msg;",
+        "outputs": 1,
+        "timeout": 0,
+        "noerr": 0,
+        "initialize": "",
+        "finalize": "",
+        "libs": [],
+        "x": 1710,
+        "y": 820,
+        "wires": [
+            [
+                "0e26ad4a81c8cec8"
+            ]
+        ]
+    },
+    {
+        "id": "fc6d1e231f9bdac4",
+        "type": "function",
+        "z": "bbc4284780ea4146",
+        "name": "Displayitem 4",
+        "func": "//// Configuration of displayitem\n// assign unique number\nvar displayitem = 4;\n// assign to a page\nvar page = \"main\";\n// add characteristics\nvar x = 70;\nvar y = 77;\nvar fontsize = 1;\nvar width = 30;\nvar label = \"Menu\";\nvar value = \"\";\nvar uom = \"\"\nvar round = 0;\nvar align = 0;\n\n// no config below this line\nvar newitem = {};\n\nnewitem = {\n    \"page\": page,\n    \"x\": x,\n    \"y\":y,\n    \"fontsize\": fontsize,\n    \"width\": width,\n    \"label\": label,\n    \"value\": value,\n    \"uom\": uom,\n    \"round\": round,\n    \"align\": align\n};\nmsg.displayitem[displayitem] = newitem;\n\n\nreturn msg;",
+        "outputs": 1,
+        "timeout": 0,
+        "noerr": 0,
+        "initialize": "",
+        "finalize": "",
+        "libs": [],
+        "x": 980,
+        "y": 1000,
+        "wires": [
+            [
+                "16bd02dea700edcf"
+            ]
+        ]
+    },
+    {
+        "id": "6a443854cee65d0e",
+        "type": "change",
+        "z": "bbc4284780ea4146",
+        "name": "",
+        "rules": [
+            {
+                "t": "set",
+                "p": "payload",
+                "pt": "msg",
+                "to": "page",
+                "tot": "msg"
+            },
+            {
+                "t": "set",
+                "p": "topic",
+                "pt": "msg",
+                "to": "buttonplus/wk1/display/main/4/value",
+                "tot": "str"
+            }
+        ],
+        "action": "",
+        "property": "",
+        "from": "",
+        "to": "",
+        "reg": false,
+        "x": 680,
+        "y": 780,
+        "wires": [
+            [
+                "e7cc598d7a6cc9f5",
+                "f978aa77a413552b"
+            ]
+        ]
+    },
+    {
+        "id": "e7cc598d7a6cc9f5",
+        "type": "mqtt out",
+        "z": "bbc4284780ea4146",
+        "name": "",
+        "topic": "",
+        "qos": "",
+        "retain": "true",
+        "respTopic": "",
+        "contentType": "",
+        "userProps": "",
+        "correl": "",
+        "expiry": "",
+        "broker": "e6dbd5fb3f32ec20",
+        "x": 850,
+        "y": 780,
+        "wires": []
+    },
+    {
+        "id": "f978aa77a413552b",
+        "type": "debug",
+        "z": "bbc4284780ea4146",
+        "name": "debug 26",
+        "active": false,
+        "tosidebar": true,
+        "console": false,
+        "tostatus": false,
+        "complete": "true",
+        "targetType": "full",
+        "statusVal": "",
+        "statusType": "auto",
+        "x": 860,
+        "y": 740,
+        "wires": []
+    },
+    {
+        "id": "15858f44f9fc05d3",
+        "type": "subflow:9fafc27b6f107add",
+        "z": "bbc4284780ea4146",
+        "name": "",
+        "x": 590,
+        "y": 120,
+        "wires": [
+            [
+                "89726a6b8d593340"
+            ],
+            [
+                "5a57757bd02eecd3"
+            ]
+        ]
+    },
+    {
+        "id": "16bd02dea700edcf",
+        "type": "switch",
+        "z": "bbc4284780ea4146",
+        "name": "",
+        "property": "page",
+        "propertyType": "msg",
+        "rules": [
+            {
+                "t": "eq",
+                "v": "avond",
+                "vt": "str"
+            },
+            {
+                "t": "eq",
+                "v": "muziek",
+                "vt": "str"
+            },
+            {
+                "t": "eq",
+                "v": "overdag",
+                "vt": "str"
+            }
+        ],
+        "checkall": "true",
+        "repair": false,
+        "outputs": 3,
+        "x": 1250,
+        "y": 840,
+        "wires": [
+            [
+                "3ced4d268c0b687d"
+            ],
+            [
+                "16fa7ded212bb8cf"
+            ],
+            [
+                "e46b4ed403416635"
+            ]
+        ]
+    },
+    {
+        "id": "e46b4ed403416635",
+        "type": "function",
+        "z": "bbc4284780ea4146",
+        "name": "Displayitem 10 (overdag)",
+        "func": "//// Configuration of displayitem\n// assign unique number\nvar displayitem = 10;\n// assign to a page\nvar page = \"ochtend\";\n// add characteristics\nvar x = 0;\nvar y = 31;\nvar fontsize = 2;\nvar width = 100;\nvar label = \"\";\nvar value = \"\";\nvar uom = \"\"\nvar round = 0;\nvar align = 0;\n\n// no config below this line\nvar newitem = {};\n\nnewitem = {\n    \"page\": page,\n    \"x\": x,\n    \"y\":y,\n    \"fontsize\": fontsize,\n    \"width\": width,\n    \"label\": label,\n    \"value\": value,\n    \"uom\": uom,\n    \"round\": round,\n    \"align\": align\n};\nmsg.displayitem[displayitem] = newitem;\n\n\nreturn msg;",
+        "outputs": 1,
+        "timeout": 0,
+        "noerr": 0,
+        "initialize": "",
+        "finalize": "",
+        "libs": [],
+        "x": 1450,
+        "y": 920,
+        "wires": [
+            [
+                "3ced4d268c0b687d"
+            ]
+        ]
+    },
+    {
+        "id": "16fa7ded212bb8cf",
+        "type": "function",
+        "z": "bbc4284780ea4146",
+        "name": "Displayitem 11 (muziek)",
+        "func": "//// Configuration of displayitem\n// assign unique number\nvar displayitem = 11;\n// assign to a page\nvar page = \"muziek\";\n// add characteristics\nvar x = 0;\nvar y = 31;\nvar fontsize = 2;\nvar width = 100;\nvar label = \"\";\nvar value = \"\";\nvar uom = \"\"\nvar round = 0;\nvar align = 0;\n\n// no config below this line\nvar newitem = {};\n\nnewitem = {\n    \"page\": page,\n    \"x\": x,\n    \"y\":y,\n    \"fontsize\": fontsize,\n    \"width\": width,\n    \"label\": label,\n    \"value\": value,\n    \"uom\": uom,\n    \"round\": round,\n    \"align\": align\n};\nmsg.displayitem[displayitem] = newitem;\n\n\nreturn msg;",
+        "outputs": 1,
+        "timeout": 0,
+        "noerr": 0,
+        "initialize": "",
+        "finalize": "",
+        "libs": [],
+        "x": 1450,
+        "y": 860,
+        "wires": [
+            [
+                "3ced4d268c0b687d"
+            ]
+        ]
+    },
+    {
+        "id": "6ccca3d893c52152",
+        "type": "function",
+        "z": "bbc4284780ea4146",
+        "name": "Assemble json object",
+        "func": "\nvar configJSON = {};\n\n// configJSON['info'] = '{ \"largedisplay\": 3, \"i2cs\": [],\"connectors\": [{\"id\": 3,\"type\": 2},{\"id\": 4,\"type\": 1}],\"sensors\": []}';\nconfigJSON['info'] = {\n        \"id\": \"wk1\",\n    \"mac\": \"F4:12:FA:45:A4:24\",\n    \"ipaddress\": \"192.168.1.81\",\n    \"firmware\": \"1.07\",\n    \"largedisplay\": 0,\n    \"connectors\": [\n      { \"id\": 0, \"type\": 2},\n      { \"id\": 1, \"type\": 1},\n      { \"id\": 2, \"type\": 1},\n      { \"id\": 3, \"type\": 1 }\n    ],\n    \"sensors\": [\n      { \"sensorid\": 1, \"description\": \"Sensirion STS35 Temperature Sensor\" }\n    ]\n  }\n\n\n\nconfigJSON['core'] = {\n \"name\": \"wk1\",\n    \"location\": \"Woonkamer 1\",\n    \"autobackup\": true,\n    \"brightnesslargedisplay\": msg.brightness,\n    \"brightnessminidisplay\": msg.brightness,\n    \"ledcolorfront\": 0,\n    \"ledcolorwall\": 0,\n    \"color\": 0\n  }\n\n\nmsg.payload = configJSON;\nreturn msg;",
+        "outputs": 1,
+        "timeout": 0,
+        "noerr": 0,
+        "initialize": "",
+        "finalize": "",
+        "libs": [],
+        "x": 660,
+        "y": 1580,
+        "wires": [
+            [
+                "3eb17d954066e070",
+                "ce37c7fc47708df2"
+            ]
+        ]
+    },
+    {
+        "id": "b6948f14f9bae1d5",
+        "type": "inject",
+        "z": "bbc4284780ea4146",
+        "name": "",
+        "props": [
+            {
+                "p": "payload"
+            },
+            {
+                "p": "topic",
+                "vt": "str"
+            }
+        ],
+        "repeat": "",
+        "crontab": "",
+        "once": false,
+        "onceDelay": 0.1,
+        "topic": "",
+        "payload": "",
+        "payloadType": "date",
+        "x": 160,
+        "y": 1760,
+        "wires": [
+            [
+                "cf45442b852ab097"
+            ]
+        ]
+    },
+    {
+        "id": "5aa5da7b63e0f07e",
+        "type": "mqtt in",
+        "z": "bbc4284780ea4146",
+        "name": "",
+        "topic": "buttonplus/wk1/brightness",
+        "qos": "1",
+        "datatype": "auto-detect",
+        "broker": "e6dbd5fb3f32ec20",
+        "nl": false,
+        "rap": true,
+        "rh": 0,
+        "inputs": 0,
+        "x": 670,
+        "y": 1480,
+        "wires": [
+            [
+                "fddeccb21f4b6d07"
+            ]
+        ]
+    },
+    {
+        "id": "bab719292e8bdf11",
+        "type": "debug",
+        "z": "bbc4284780ea4146",
+        "name": "debug 29",
+        "active": false,
+        "tosidebar": true,
+        "console": false,
+        "tostatus": false,
+        "complete": "true",
+        "targetType": "full",
+        "statusVal": "",
+        "statusType": "auto",
+        "x": 140,
+        "y": 1920,
+        "wires": []
+    },
+    {
+        "id": "80ae01cb3386336c",
+        "type": "http request",
+        "z": "bbc4284780ea4146",
+        "name": "Post JSON",
+        "method": "POST",
+        "ret": "txt",
+        "paytoqs": "body",
+        "url": "",
+        "tls": "",
+        "persist": true,
+        "proxy": "",
+        "insecureHTTPParser": false,
+        "authType": "",
+        "senderr": false,
+        "headers": [
+            {
+                "keyType": "Content-Type",
+                "keyValue": "",
+                "valueType": "other",
+                "valueValue": "application/json"
+            }
+        ],
+        "x": 150,
+        "y": 1880,
+        "wires": [
+            [
+                "bab719292e8bdf11"
+            ]
+        ]
+    },
+    {
+        "id": "dc5f8b025f5e035d",
+        "type": "function",
+        "z": "bbc4284780ea4146",
+        "name": "Set headers",
+        "func": "msg.payload = {}\n\nmsg.url='http://192.168.1.81/configsave'\n\n\nmsg.headers = {};\nmsg.headers[\"Accept\"] = 'application/json';\nmsg.headers[\"Accept-Encoding\"] = 'gzip, deflate, br';\nmsg.headers[\"json\"] = true;\nreturn msg;\n",
+        "outputs": 1,
+        "timeout": 0,
+        "noerr": 0,
+        "initialize": "",
+        "finalize": "",
+        "libs": [],
+        "x": 150,
+        "y": 1840,
+        "wires": [
+            [
+                "80ae01cb3386336c"
+            ]
+        ],
+        "icon": "font-awesome/fa-lock"
+    },
+    {
+        "id": "cf45442b852ab097",
+        "type": "function",
+        "z": "bbc4284780ea4146",
+        "name": "Assemble json object",
+        "func": "var configJSON = {};\n\n// configJSON['info'] = '{ \"largedisplay\": 3, \"i2cs\": [],\"connectors\": [{\"id\": 3,\"type\": 2},{\"id\": 4,\"type\": 1}],\"sensors\": []}';\nconfigJSON['info'] = {\n        \"id\": \"btn_45a424\",\n    \"mac\": \"F4:12:FA:45:A4:24\",\n    \"ipaddress\": \"192.168.1.81\",\n    \"firmware\": \"1.07\",\n    \"largedisplay\": 0,\n    \"connectors\": [\n      { \"id\": 0, \"type\": 2},\n      { \"id\": 1, \"type\": 1},\n      { \"id\": 2, \"type\": 1},\n      { \"id\": 3, \"type\": 1 }\n    ],\n    \"sensors\": [\n      { \"sensorid\": 1, \"description\": \"Sensirion STS35 Temperature Sensor\" }\n    ]\n  }\n\n\n\nconfigJSON['core'] = {\n \"name\": \"btn_45a424\",\n    \"location\": \"Room 1\",\n    \"autobackup\": true,\n    \"brightnesslargedisplay\": 60,\n    \"brightnessminidisplay\": 50,\n    \"ledcolorfront\": 0,\n    \"ledcolorwall\": 0,\n    \"color\": 0\n  }\nconfigJSON['mqttbuttons'] = msg.mqttbuttons;\nconfigJSON['mqttdisplays'] = msg.displayitem;\nconfigJSON['mqttbrokers'] =  [\n    {\n            \"brokerid\": \"buttonplus\",\n            \"url\": \"mqtt://mqtt.button.plus\",\n            \"port\": 0,\n            \"wsport\": 0,\n            \"username\": \"\",\n            \"password\": \"\"\n        },{\n\n            \"brokerid\": \"ha\",\n            \"url\": \"mqtt://192.168.1.7\",\n            \"port\": 1883,\n            \"wsport\": 0,\n            \"username\": \"mqtt\",\n            \"password\": \"mqtt\"\n    }\n  ];\nconfigJSON['mqttsensors'] = [\n    {\n      \"sensorid\": 1,\n      \"topic\": {\n        \"brokerid\": \"buttonplus\",\n        \"topic\": \"button/btn_45a424/temperature\",\n        \"payload\": \"\",\n        \"eventtype\": 18\n      },\n      \"interval\": 10\n    }\n];\n\nmsg.payload = configJSON;\nreturn msg;",
+        "outputs": 1,
+        "timeout": 0,
+        "noerr": 0,
+        "initialize": "",
+        "finalize": "",
+        "libs": [],
+        "x": 180,
+        "y": 1800,
+        "wires": [
+            [
+                "dc5f8b025f5e035d"
+            ]
+        ]
+    },
+    {
+        "id": "d95b2a1be63cac90",
+        "type": "comment",
+        "z": "bbc4284780ea4146",
+        "name": "Backup of working JSON (void)",
+        "info": "",
+        "x": 210,
+        "y": 1720,
+        "wires": []
+    },
+    {
+        "id": "fddeccb21f4b6d07",
+        "type": "function",
+        "z": "bbc4284780ea4146",
+        "name": "Parse brightness from MQTT",
+        "func": "var brightness = parseInt(msg.payload);\nflow.set('brightness', brightness);\nmsg.brightness = brightness;\n\n\nreturn msg;",
+        "outputs": 1,
+        "timeout": 0,
+        "noerr": 0,
+        "initialize": "",
+        "finalize": "",
+        "libs": [],
+        "x": 680,
+        "y": 1540,
+        "wires": [
+            [
+                "6ccca3d893c52152"
+            ]
+        ]
+    },
+    {
+        "id": "ce37c7fc47708df2",
+        "type": "debug",
+        "z": "bbc4284780ea4146",
+        "name": "debug 30",
+        "active": true,
+        "tosidebar": true,
+        "console": false,
+        "tostatus": false,
+        "complete": "false",
+        "statusVal": "",
+        "statusType": "auto",
+        "x": 620,
+        "y": 1620,
+        "wires": []
+    },
+    {
+        "id": "e43a6503a12fa1ab",
+        "type": "change",
+        "z": "bbc4284780ea4146",
+        "name": "btn_click",
+        "rules": [
+            {
+                "t": "set",
+                "p": "action_type",
+                "pt": "msg",
+                "to": "click",
+                "tot": "str"
+            }
+        ],
+        "action": "",
+        "property": "",
+        "from": "",
+        "to": "",
+        "reg": false,
+        "x": 100,
+        "y": 220,
+        "wires": [
+            [
+                "b5071d75c23ccfef"
+            ]
+        ]
+    },
+    {
+        "id": "8dcdda3c8146f1ba",
+        "type": "change",
+        "z": "bbc4284780ea4146",
+        "name": "btn_release",
+        "rules": [
+            {
+                "t": "set",
+                "p": "action_type",
+                "pt": "msg",
+                "to": "release",
+                "tot": "str"
+            }
+        ],
+        "action": "",
+        "property": "",
+        "from": "",
+        "to": "",
+        "reg": false,
+        "x": 130,
+        "y": 300,
+        "wires": [
+            [
+                "b5071d75c23ccfef"
+            ]
+        ]
+    },
+    {
+        "id": "86611e149f10f4d4",
+        "type": "change",
+        "z": "bbc4284780ea4146",
+        "name": "",
+        "rules": [
+            {
+                "t": "set",
+                "p": "btn_click",
+                "pt": "msg",
+                "to": "payload",
+                "tot": "msg"
+            }
+        ],
+        "action": "",
+        "property": "",
+        "from": "",
+        "to": "",
+        "reg": false,
+        "x": 130,
+        "y": 180,
+        "wires": [
+            [
+                "e43a6503a12fa1ab"
+            ]
+        ]
+    },
+    {
+        "id": "9b7ca79530c71d64",
+        "type": "mqtt in",
+        "z": "bbc4284780ea4146",
+        "name": "",
+        "topic": "buttonplus/wk1/button/+/+/state",
+        "qos": "2",
+        "datatype": "auto-detect",
+        "broker": "e6dbd5fb3f32ec20",
+        "nl": false,
+        "rap": true,
+        "rh": 0,
+        "inputs": 0,
+        "x": 150,
+        "y": 100,
+        "wires": [
+            [
+                "5ca20baf4991e0b1"
+            ]
+        ]
+    },
+    {
+        "id": "5ca20baf4991e0b1",
+        "type": "function",
+        "z": "bbc4284780ea4146",
+        "name": "Split topic",
+        "func": "var topic = msg.topic;\ntopic = topic.split(\"/\");\n\nmsg.page = topic[3];\nmsg.button = topic[4];\nmsg.state = topic[5];\n\nreturn msg;",
+        "outputs": 1,
+        "timeout": 0,
+        "noerr": 0,
+        "initialize": "",
+        "finalize": "",
+        "libs": [],
+        "x": 100,
+        "y": 140,
+        "wires": [
+            [
+                "86611e149f10f4d4"
+            ]
+        ]
+    },
+    {
+        "id": "c6de25db8019ed6e",
+        "type": "comment",
+        "z": "bbc4284780ea4146",
+        "name": "Signal from button 1, changes to next page",
+        "info": "",
+        "x": 950,
+        "y": 80,
+        "wires": []
+    },
+    {
+        "id": "8aad1b3403676f8c",
+        "type": "comment",
+        "z": "bbc4284780ea4146",
+        "name": "Trigger to change menu from button",
+        "info": "",
+        "x": 320,
+        "y": 680,
+        "wires": []
+    },
+    {
+        "id": "68c8e3f412f0f313",
+        "type": "comment",
+        "z": "bbc4284780ea4146",
+        "name": "Trigger to change menu from HA",
+        "info": "",
+        "x": 150,
+        "y": 780,
+        "wires": []
+    },
+    {
+        "id": "f8210e82d8b29a39",
+        "type": "comment",
+        "z": "bbc4284780ea4146",
+        "name": "Issue new page title to MQTT",
+        "info": "",
+        "x": 620,
+        "y": 740,
+        "wires": []
+    },
+    {
+        "id": "28b27c4de8787982",
+        "type": "comment",
+        "z": "bbc4284780ea4146",
+        "name": "Contain the default button labels",
+        "info": "",
+        "x": 510,
+        "y": 1220,
+        "wires": []
+    },
+    {
+        "id": "8ea4d14d647290cb",
+        "type": "comment",
+        "z": "bbc4284780ea4146",
+        "name": "Listen to brightness triggers",
+        "info": "Partial update of B+",
+        "x": 680,
+        "y": 1440,
+        "wires": []
+    },
+    {
+        "id": "09405e7b9e062b41",
+        "type": "comment",
+        "z": "bbc4284780ea4146",
+        "name": "Displayitems for Main",
+        "info": "",
+        "x": 1000,
+        "y": 840,
+        "wires": []
+    },
+    {
+        "id": "3646108c0ac15193",
+        "type": "comment",
+        "z": "bbc4284780ea4146",
+        "name": "Displayitems from pages",
+        "info": "",
+        "x": 1430,
+        "y": 780,
+        "wires": []
+    },
+    {
+        "id": "5d966a3e21fccf2b",
+        "type": "comment",
+        "z": "bbc4284780ea4146",
+        "name": "Button definition",
+        "info": "Example:\nmsg.pagebutton.0 = \"main\" --> always belongs to main page\nmsg.pagebutton.2 = msg.page --> is dynamically assigned to page",
+        "x": 480,
+        "y": 1000,
+        "wires": []
+    },
+    {
+        "id": "e5e8d6ef7143d479",
+        "type": "comment",
+        "z": "bbc4284780ea4146",
+        "name": "Assembly of button JSON",
+        "info": "based on upstream page definition\n\nprepares a JSON each time a page is changed",
+        "x": 710,
+        "y": 840,
+        "wires": []
+    },
+    {
+        "id": "cf616ebb6d2b389b",
+        "type": "comment",
+        "z": "bbc4284780ea4146",
+        "name": "Update MQTT topics for button labels ",
+        "info": "",
+        "x": 790,
+        "y": 1260,
+        "wires": []
+    },
+    {
+        "id": "43c66b546e97baf5",
+        "type": "comment",
+        "z": "bbc4284780ea4146",
+        "name": "Prepare Displayitems JSON",
+        "info": "based on upstream definition",
+        "x": 1760,
+        "y": 780,
+        "wires": []
+    },
+    {
+        "id": "3b11356d45d0b641",
+        "type": "comment",
+        "z": "bbc4284780ea4146",
+        "name": "Combine JSON objects",
+        "info": "and prepare upload to JSON",
+        "x": 1320,
+        "y": 1080,
+        "wires": []
+    }
+]

--- a/node_red_update_display.flow
+++ b/node_red_update_display.flow
@@ -1,1 +1,1321 @@
-[{"id":"fd2bb19b59cf119e","type":"subflow","name":"B+ MQTT to main","info":"","category":"","in":[{"x":80,"y":100,"wires":[{"id":"94a06ba2b812bfa9"}]}],"out":[],"env":[],"meta":{},"color":"#DDAA99"},{"id":"0184922774fbede3","type":"mqtt out","z":"fd2bb19b59cf119e","name":"value","topic":"","qos":"0","retain":"true","respTopic":"","contentType":"","userProps":"","correl":"","expiry":"","broker":"e6dbd5fb3f32ec20","x":730,"y":360,"wires":[]},{"id":"59db74a4adc9a31f","type":"change","z":"fd2bb19b59cf119e","name":"","rules":[{"t":"set","p":"payload","pt":"msg","to":"label","tot":"msg"}],"action":"","property":"","from":"","to":"","reg":false,"x":540,"y":300,"wires":[["9169f4d5de7f5aa2"]]},{"id":"9169f4d5de7f5aa2","type":"mqtt out","z":"fd2bb19b59cf119e","name":"title","topic":"","qos":"0","retain":"true","respTopic":"","contentType":"","userProps":"","correl":"","expiry":"","broker":"e6dbd5fb3f32ec20","x":730,"y":300,"wires":[]},{"id":"cf7dbf4993cc51d8","type":"mqtt out","z":"fd2bb19b59cf119e","name":"uom","topic":"","qos":"0","retain":"true","respTopic":"","contentType":"","userProps":"","correl":"","expiry":"","broker":"e6dbd5fb3f32ec20","x":730,"y":240,"wires":[]},{"id":"e477e4949ea48f65","type":"change","z":"fd2bb19b59cf119e","name":"","rules":[{"t":"set","p":"payload","pt":"msg","to":"uom","tot":"msg"}],"action":"","property":"","from":"","to":"","reg":false,"x":540,"y":240,"wires":[["cf7dbf4993cc51d8"]]},{"id":"e387eac66190fe70","type":"function","z":"fd2bb19b59cf119e","name":"concat uom","func":"var appendix='uom'\nmsg.topic = msg.topic.concat(appendix)\nreturn msg;","outputs":1,"noerr":0,"initialize":"","finalize":"","libs":[],"x":330,"y":240,"wires":[["e477e4949ea48f65"]]},{"id":"3c67118b2fe0bb35","type":"function","z":"fd2bb19b59cf119e","name":"concat label","func":"var appendix='label'\nmsg.topic = msg.topic.concat(appendix)\nreturn msg;","outputs":1,"timeout":"","noerr":0,"initialize":"","finalize":"","libs":[],"x":330,"y":300,"wires":[["59db74a4adc9a31f"]]},{"id":"849c57c4154e9b1c","type":"function","z":"fd2bb19b59cf119e","name":"concat value","func":"var appendix='value'\nmsg.topic = msg.topic.concat(appendix)\nreturn msg;","outputs":1,"timeout":"","noerr":0,"initialize":"","finalize":"","libs":[],"x":330,"y":360,"wires":[["0184922774fbede3"]]},{"id":"94a06ba2b812bfa9","type":"function","z":"fd2bb19b59cf119e","name":"set topic","func":"msg.topic = \"buttonplus/\"+msg.device+\"/display/\"+msg.displayitem+\"/\";\nreturn msg;","outputs":1,"timeout":0,"noerr":0,"initialize":"","finalize":"","libs":[],"x":140,"y":300,"wires":[["e387eac66190fe70","3c67118b2fe0bb35","849c57c4154e9b1c"]]},{"id":"e6dbd5fb3f32ec20","type":"mqtt-broker","name":"","broker":"192.168.1.7","port":"1883","clientid":"","autoConnect":true,"usetls":false,"protocolVersion":"4","keepalive":"60","cleansession":true,"autoUnsubscribe":true,"birthTopic":"","birthQos":"0","birthPayload":"","birthMsg":{},"closeTopic":"","closeQos":"0","closePayload":"","closeMsg":{},"willTopic":"","willQos":"0","willPayload":"","willMsg":{},"userProps":"","sessionExpiry":""},{"id":"dda605bd4ff9ca6b","type":"tab","label":"Button+","disabled":false,"info":"","env":[]},{"id":"def85d44acd7ae1f","type":"subflow:fd2bb19b59cf119e","z":"dda605bd4ff9ca6b","name":"","x":730,"y":100,"wires":[]},{"id":"5585d907fa2f3f30","type":"debug","z":"dda605bd4ff9ca6b","name":"debug 2","active":false,"tosidebar":true,"console":false,"tostatus":false,"complete":"true","targetType":"full","statusVal":"","statusType":"auto","x":720,"y":160,"wires":[]},{"id":"5e63cffe051c7270","type":"switch","z":"dda605bd4ff9ca6b","name":"","property":"source","propertyType":"msg","rules":[{"t":"eq","v":"Woonkamer","vt":"str"},{"t":"else"}],"checkall":"true","repair":false,"outputs":2,"x":480,"y":700,"wires":[["4335ac1ad2ec79e0"],["20d33fb7fb73d171"]]},{"id":"4335ac1ad2ec79e0","type":"change","z":"dda605bd4ff9ca6b","name":"","rules":[{"t":"set","p":"payload","pt":"msg","to":"msg.media_artist & \" - \" & msg.media_title","tot":"jsonata"}],"action":"","property":"","from":"","to":"","reg":false,"x":690,"y":680,"wires":[["e83ea66daaf0b095","7a94d2dc5523d3a9"]]},{"id":"e83ea66daaf0b095","type":"subflow:fd2bb19b59cf119e","z":"dda605bd4ff9ca6b","name":"","x":960,"y":700,"wires":[]},{"id":"20d33fb7fb73d171","type":"change","z":"dda605bd4ff9ca6b","name":"","rules":[{"t":"set","p":"payload","pt":"msg","to":"","tot":"str"}],"action":"","property":"","from":"","to":"","reg":false,"x":690,"y":720,"wires":[["e83ea66daaf0b095"]]},{"id":"678539c7ea352922","type":"function","z":"dda605bd4ff9ca6b","name":"concat value","func":"var appendix='value'\nmsg.topic = msg.topic.concat(appendix)\nreturn msg;","outputs":1,"noerr":0,"initialize":"","finalize":"","libs":[],"x":660,"y":820,"wires":[[]]},{"id":"7a94d2dc5523d3a9","type":"debug","z":"dda605bd4ff9ca6b","name":"debug 8","active":true,"tosidebar":true,"console":false,"tostatus":false,"complete":"false","statusVal":"","statusType":"auto","x":1090,"y":860,"wires":[]},{"id":"5c4f8fd575f74583","type":"subflow:fd2bb19b59cf119e","z":"dda605bd4ff9ca6b","name":"","x":689,"y":886,"wires":[]},{"id":"85f97a48c12dd796","type":"debug","z":"dda605bd4ff9ca6b","name":"debug 9","active":false,"tosidebar":true,"console":false,"tostatus":false,"complete":"uom","targetType":"msg","statusVal":"","statusType":"auto","x":579,"y":1006,"wires":[]},{"id":"840bde6727a030a0","type":"change","z":"dda605bd4ff9ca6b","name":"","rules":[{"t":"set","p":"label","pt":"msg","to":"Gemeten","tot":"str"}],"action":"","property":"","from":"","to":"","reg":false,"x":510,"y":100,"wires":[["def85d44acd7ae1f","5585d907fa2f3f30"]]},{"id":"77ac129d00b347c1","type":"comment","z":"dda605bd4ff9ca6b","name":"Displayitem 1","info":"","x":170,"y":60,"wires":[]},{"id":"39a53e1d9a445841","type":"subflow:fd2bb19b59cf119e","z":"dda605bd4ff9ca6b","name":"","x":730,"y":240,"wires":[]},{"id":"7d3326a0ec6856fe","type":"debug","z":"dda605bd4ff9ca6b","name":"debug 21","active":false,"tosidebar":true,"console":false,"tostatus":false,"complete":"true","targetType":"full","statusVal":"","statusType":"auto","x":720,"y":300,"wires":[]},{"id":"95930f12d9e9a004","type":"change","z":"dda605bd4ff9ca6b","name":"","rules":[{"t":"set","p":"label","pt":"msg","to":"Ingesteld","tot":"str"}],"action":"","property":"","from":"","to":"","reg":false,"x":510,"y":240,"wires":[["39a53e1d9a445841","7d3326a0ec6856fe"]]},{"id":"75b758a921fca3eb","type":"comment","z":"dda605bd4ff9ca6b","name":"Displayitem 2 (aangepast blok)","info":"","x":230,"y":200,"wires":[]},{"id":"bc3fea2c6f17b7fa","type":"api-current-state","z":"dda605bd4ff9ca6b","name":"","server":"c5f56a3a.f3f838","version":3,"outputs":1,"halt_if":"","halt_if_type":"str","halt_if_compare":"is","entity_id":"sensor.delft_precipitation_forecast_total","state_type":"str","blockInputOverrides":false,"outputProperties":[{"property":"payload","propertyType":"msg","value":"","valueType":"entityState"},{"property":"data","propertyType":"msg","value":"","valueType":"entity"}],"for":"0","forType":"num","forUnits":"minutes","override_topic":false,"state_location":"payload","override_payload":"msg","entity_location":"data","override_data":"msg","x":280,"y":620,"wires":[[]]},{"id":"8f62a92116d42782","type":"server-state-changed","z":"dda605bd4ff9ca6b","name":"Woonkamer temperatuur","server":"c5f56a3a.f3f838","version":5,"outputs":1,"exposeAsEntityConfig":"","entityId":"sensor.woonkamer_temperature","entityIdType":"exact","outputInitially":true,"stateType":"num","ifState":"","ifStateType":"str","ifStateOperator":"is","outputOnlyOnStateChange":true,"for":"0","forType":"num","forUnits":"minutes","ignorePrevStateNull":false,"ignorePrevStateUnknown":false,"ignorePrevStateUnavailable":false,"ignoreCurrentStateUnknown":false,"ignoreCurrentStateUnavailable":false,"outputProperties":[{"property":"payload","propertyType":"msg","value":"","valueType":"entityState"},{"property":"uom","propertyType":"msg","value":"$entity().attributes.unit_of_measurement","valueType":"jsonata"},{"property":"label","propertyType":"msg","value":"$entity().attributes.friendly_name","valueType":"jsonata"},{"property":"displayitem","propertyType":"msg","value":"1","valueType":"str"},{"property":"device","propertyType":"msg","value":"wk1","valueType":"str"}],"x":210,"y":100,"wires":[["840bde6727a030a0"]]},{"id":"06aea980c602425e","type":"server-state-changed","z":"dda605bd4ff9ca6b","name":"","server":"c5f56a3a.f3f838","version":5,"outputs":1,"exposeAsEntityConfig":"","entityId":"media_player.spotify_sbalk","entityIdType":"exact","outputInitially":true,"stateType":"str","ifState":"","ifStateType":"str","ifStateOperator":"is","outputOnlyOnStateChange":true,"for":"0","forType":"num","forUnits":"minutes","ignorePrevStateNull":false,"ignorePrevStateUnknown":false,"ignorePrevStateUnavailable":false,"ignoreCurrentStateUnknown":false,"ignoreCurrentStateUnavailable":false,"outputProperties":[{"property":"payload","propertyType":"msg","value":"","valueType":"entityState"},{"property":"uom","propertyType":"msg","value":"$entity().attributes.unit_of_measurement","valueType":"jsonata"},{"property":"title","propertyType":"msg","value":"Now playing","valueType":"str"},{"property":"topic","propertyType":"msg","value":"buttonplus/wk1/main/in/4/","valueType":"str"},{"property":"source","propertyType":"msg","value":"$entity().attributes.source","valueType":"jsonata"},{"property":"media_title","propertyType":"msg","value":"$entity().attributes.media_title","valueType":"jsonata"},{"property":"media_artist","propertyType":"msg","value":"$entity().attributes.media_artist","valueType":"jsonata"}],"x":240,"y":700,"wires":[["5e63cffe051c7270"]]},{"id":"1233d0753de517f0","type":"server-state-changed","z":"dda605bd4ff9ca6b","name":"","server":"c5f56a3a.f3f838","version":5,"outputs":1,"exposeAsEntityConfig":"","entityId":"sensor.buienalarm_precipitation_forecast_total","entityIdType":"exact","outputInitially":true,"stateType":"num","ifState":"","ifStateType":"str","ifStateOperator":"is","outputOnlyOnStateChange":true,"for":"0","forType":"num","forUnits":"minutes","ignorePrevStateNull":false,"ignorePrevStateUnknown":false,"ignorePrevStateUnavailable":false,"ignoreCurrentStateUnknown":false,"ignoreCurrentStateUnavailable":false,"outputProperties":[{"property":"payload","propertyType":"msg","value":"","valueType":"entityState"},{"property":"uom","propertyType":"msg","value":"$entity().attributes.unit_of_measurement","valueType":"jsonata"},{"property":"title","propertyType":"msg","value":"Regen 15min","valueType":"str"},{"property":"topic","propertyType":"msg","value":"buttonplus/wk1/main/in/5/","valueType":"str"}],"x":330,"y":880,"wires":[["5c4f8fd575f74583","85f97a48c12dd796"]]},{"id":"0b4dbfb79cec893a","type":"server-state-changed","z":"dda605bd4ff9ca6b","name":"Ingestelde temperatuur","server":"c5f56a3a.f3f838","version":5,"outputs":1,"exposeAsEntityConfig":"","entityId":"climate.woonkamer","entityIdType":"exact","outputInitially":true,"stateType":"num","ifState":"","ifStateType":"str","ifStateOperator":"is","outputOnlyOnStateChange":true,"for":"0","forType":"num","forUnits":"minutes","ignorePrevStateNull":false,"ignorePrevStateUnknown":false,"ignorePrevStateUnavailable":false,"ignoreCurrentStateUnknown":false,"ignoreCurrentStateUnavailable":false,"outputProperties":[{"property":"payload","propertyType":"msg","value":"$entity().attributes.temperature","valueType":"jsonata"},{"property":"uom","propertyType":"msg","value":"$entity().attributes.unit_of_measurement","valueType":"jsonata"},{"property":"label","propertyType":"msg","value":"$entity().attributes.friendly_name","valueType":"jsonata"},{"property":"displayitem","propertyType":"msg","value":"2","valueType":"str"},{"property":"device","propertyType":"msg","value":"wk1","valueType":"str"}],"x":200,"y":240,"wires":[["95930f12d9e9a004"]]},{"id":"173ceffe137b21a9","type":"subflow:fd2bb19b59cf119e","z":"dda605bd4ff9ca6b","name":"","x":730,"y":440,"wires":[]},{"id":"dcf28ad761fd5922","type":"debug","z":"dda605bd4ff9ca6b","name":"debug 25","active":true,"tosidebar":true,"console":false,"tostatus":false,"complete":"true","targetType":"full","statusVal":"","statusType":"auto","x":720,"y":500,"wires":[]},{"id":"e0ba654526d58375","type":"change","z":"dda605bd4ff9ca6b","name":"","rules":[{"t":"set","p":"device","pt":"msg","to":"wk1","tot":"str"},{"t":"set","p":"displayitem","pt":"msg","to":"6","tot":"str"}],"action":"","property":"","from":"","to":"","reg":false,"x":520,"y":440,"wires":[["173ceffe137b21a9"]]},{"id":"4ae39b93e4e5d9c9","type":"comment","z":"dda605bd4ff9ca6b","name":"Displayitem 6 (aangepast blok)","info":"","x":230,"y":400,"wires":[]},{"id":"46cba9840f0bc890","type":"server-state-changed","z":"dda605bd4ff9ca6b","name":"Tijd","server":"c5f56a3a.f3f838","version":5,"outputs":1,"exposeAsEntityConfig":"","entityId":"sensor.time","entityIdType":"exact","outputInitially":true,"stateType":"str","ifState":"","ifStateType":"str","ifStateOperator":"is","outputOnlyOnStateChange":true,"for":"0","forType":"num","forUnits":"minutes","ignorePrevStateNull":false,"ignorePrevStateUnknown":false,"ignorePrevStateUnavailable":false,"ignoreCurrentStateUnknown":false,"ignoreCurrentStateUnavailable":false,"outputProperties":[{"property":"payload","propertyType":"msg","value":"","valueType":"entityState"},{"property":"displayitem","propertyType":"msg","value":"6","valueType":"str"},{"property":"device","propertyType":"msg","value":"wk1","valueType":"str"}],"x":150,"y":440,"wires":[["e0ba654526d58375"]]},{"id":"13befc1ff21e3205","type":"server-state-changed","z":"dda605bd4ff9ca6b","name":"Datum","server":"c5f56a3a.f3f838","version":5,"outputs":1,"exposeAsEntityConfig":"","entityId":"sensor.date","entityIdType":"exact","outputInitially":true,"stateType":"str","ifState":"","ifStateType":"str","ifStateOperator":"is","outputOnlyOnStateChange":true,"for":"0","forType":"num","forUnits":"minutes","ignorePrevStateNull":false,"ignorePrevStateUnknown":false,"ignorePrevStateUnavailable":false,"ignoreCurrentStateUnknown":false,"ignoreCurrentStateUnavailable":false,"outputProperties":[{"property":"label","propertyType":"msg","value":"","valueType":"entityState"},{"property":"displayitem","propertyType":"msg","value":"6","valueType":"str"},{"property":"device","propertyType":"msg","value":"wk1","valueType":"str"}],"x":150,"y":500,"wires":[["69c067cb360038b9"]]},{"id":"69c067cb360038b9","type":"moment","z":"dda605bd4ff9ca6b","name":"format date","topic":"","input":"label","inputType":"msg","inTz":"Europe/Amsterdam","adjAmount":0,"adjType":"days","adjDir":"add","format":"D MMMM","locale":"nl","output":"label","outputType":"msg","outTz":"Europe/Amsterdam","x":290,"y":500,"wires":[["e0ba654526d58375"]]},{"id":"c5f56a3a.f3f838","type":"server","name":"Home Assistant","version":5,"addon":true,"rejectUnauthorizedCerts":true,"ha_boolean":"y|yes|true|on|home|open","connectionDelay":true,"cacheJson":true,"heartbeat":false,"heartbeatInterval":"30","areaSelector":"friendlyName","deviceSelector":"friendlyName","entitySelector":"friendlyName","statusSeparator":"at: ","statusYear":"hidden","statusMonth":"short","statusDay":"numeric","statusHourCycle":"h23","statusTimeFormat":"h:m","enableGlobalContextStore":true}]
+[
+    {
+        "id": "ee7dfcae62a1d1d1",
+        "type": "subflow",
+        "name": "B+ MQTT to main",
+        "info": "",
+        "category": "",
+        "in": [
+            {
+                "x": 80,
+                "y": 100,
+                "wires": [
+                    {
+                        "id": "a49cd7b39edf50ad"
+                    }
+                ]
+            }
+        ],
+        "out": [],
+        "env": [],
+        "meta": {},
+        "color": "#DDAA99"
+    },
+    {
+        "id": "96d164091bca558c",
+        "type": "mqtt out",
+        "z": "ee7dfcae62a1d1d1",
+        "name": "value",
+        "topic": "",
+        "qos": "0",
+        "retain": "true",
+        "respTopic": "",
+        "contentType": "",
+        "userProps": "",
+        "correl": "",
+        "expiry": "",
+        "broker": "e6dbd5fb3f32ec20",
+        "x": 730,
+        "y": 360,
+        "wires": []
+    },
+    {
+        "id": "523048e5478dc2ba",
+        "type": "change",
+        "z": "ee7dfcae62a1d1d1",
+        "name": "",
+        "rules": [
+            {
+                "t": "set",
+                "p": "payload",
+                "pt": "msg",
+                "to": "label",
+                "tot": "msg"
+            }
+        ],
+        "action": "",
+        "property": "",
+        "from": "",
+        "to": "",
+        "reg": false,
+        "x": 540,
+        "y": 300,
+        "wires": [
+            [
+                "b18f1afeaa130737"
+            ]
+        ]
+    },
+    {
+        "id": "b18f1afeaa130737",
+        "type": "mqtt out",
+        "z": "ee7dfcae62a1d1d1",
+        "name": "title",
+        "topic": "",
+        "qos": "0",
+        "retain": "true",
+        "respTopic": "",
+        "contentType": "",
+        "userProps": "",
+        "correl": "",
+        "expiry": "",
+        "broker": "e6dbd5fb3f32ec20",
+        "x": 730,
+        "y": 300,
+        "wires": []
+    },
+    {
+        "id": "e343e9a04e0cf6df",
+        "type": "mqtt out",
+        "z": "ee7dfcae62a1d1d1",
+        "name": "uom",
+        "topic": "",
+        "qos": "0",
+        "retain": "true",
+        "respTopic": "",
+        "contentType": "",
+        "userProps": "",
+        "correl": "",
+        "expiry": "",
+        "broker": "e6dbd5fb3f32ec20",
+        "x": 730,
+        "y": 240,
+        "wires": []
+    },
+    {
+        "id": "2906bb2e666b787a",
+        "type": "change",
+        "z": "ee7dfcae62a1d1d1",
+        "name": "",
+        "rules": [
+            {
+                "t": "set",
+                "p": "payload",
+                "pt": "msg",
+                "to": "uom",
+                "tot": "msg"
+            }
+        ],
+        "action": "",
+        "property": "",
+        "from": "",
+        "to": "",
+        "reg": false,
+        "x": 540,
+        "y": 240,
+        "wires": [
+            [
+                "e343e9a04e0cf6df"
+            ]
+        ]
+    },
+    {
+        "id": "4b58c6126865041d",
+        "type": "function",
+        "z": "ee7dfcae62a1d1d1",
+        "name": "concat uom",
+        "func": "var appendix='uom'\nmsg.topic = msg.topic.concat(appendix)\nreturn msg;",
+        "outputs": 1,
+        "noerr": 0,
+        "initialize": "",
+        "finalize": "",
+        "libs": [],
+        "x": 330,
+        "y": 240,
+        "wires": [
+            [
+                "2906bb2e666b787a"
+            ]
+        ]
+    },
+    {
+        "id": "ef07977994e4e2f4",
+        "type": "function",
+        "z": "ee7dfcae62a1d1d1",
+        "name": "concat label",
+        "func": "var appendix='label'\nmsg.topic = msg.topic.concat(appendix)\nreturn msg;",
+        "outputs": 1,
+        "timeout": "",
+        "noerr": 0,
+        "initialize": "",
+        "finalize": "",
+        "libs": [],
+        "x": 330,
+        "y": 300,
+        "wires": [
+            [
+                "523048e5478dc2ba"
+            ]
+        ]
+    },
+    {
+        "id": "7611744803215c96",
+        "type": "function",
+        "z": "ee7dfcae62a1d1d1",
+        "name": "concat value",
+        "func": "var appendix='value'\nmsg.topic = msg.topic.concat(appendix)\nreturn msg;",
+        "outputs": 1,
+        "timeout": "",
+        "noerr": 0,
+        "initialize": "",
+        "finalize": "",
+        "libs": [],
+        "x": 330,
+        "y": 360,
+        "wires": [
+            [
+                "96d164091bca558c"
+            ]
+        ]
+    },
+    {
+        "id": "a49cd7b39edf50ad",
+        "type": "function",
+        "z": "ee7dfcae62a1d1d1",
+        "name": "set topic",
+        "func": "msg.topic = \"buttonplus/\"+msg.device+\"/display/\"+msg.page+\"/\"+msg.displayitem+\"/\";\nreturn msg;",
+        "outputs": 1,
+        "timeout": 0,
+        "noerr": 0,
+        "initialize": "",
+        "finalize": "",
+        "libs": [],
+        "x": 140,
+        "y": 300,
+        "wires": [
+            [
+                "4b58c6126865041d",
+                "ef07977994e4e2f4",
+                "7611744803215c96"
+            ]
+        ]
+    },
+    {
+        "id": "e6dbd5fb3f32ec20",
+        "type": "mqtt-broker",
+        "name": "",
+        "broker": "192.168.1.7",
+        "port": "1883",
+        "clientid": "",
+        "autoConnect": true,
+        "usetls": false,
+        "protocolVersion": "4",
+        "keepalive": "60",
+        "cleansession": true,
+        "birthTopic": "",
+        "birthQos": "0",
+        "birthPayload": "",
+        "birthMsg": {},
+        "closeTopic": "",
+        "closeQos": "0",
+        "closePayload": "",
+        "closeMsg": {},
+        "willTopic": "",
+        "willQos": "0",
+        "willPayload": "",
+        "willMsg": {},
+        "userProps": "",
+        "sessionExpiry": ""
+    },
+    {
+        "id": "1044a74b4adb9c61",
+        "type": "tab",
+        "label": "Button+",
+        "disabled": false,
+        "info": "",
+        "env": []
+    },
+    {
+        "id": "b5eadadbf165db94",
+        "type": "subflow:ee7dfcae62a1d1d1",
+        "z": "1044a74b4adb9c61",
+        "name": "",
+        "x": 730,
+        "y": 100,
+        "wires": []
+    },
+    {
+        "id": "76595fb85bdd4174",
+        "type": "debug",
+        "z": "1044a74b4adb9c61",
+        "name": "debug 2",
+        "active": false,
+        "tosidebar": true,
+        "console": false,
+        "tostatus": false,
+        "complete": "true",
+        "targetType": "full",
+        "statusVal": "",
+        "statusType": "auto",
+        "x": 720,
+        "y": 160,
+        "wires": []
+    },
+    {
+        "id": "9c81d00921e7a289",
+        "type": "switch",
+        "z": "1044a74b4adb9c61",
+        "d": true,
+        "name": "",
+        "property": "source",
+        "propertyType": "msg",
+        "rules": [
+            {
+                "t": "eq",
+                "v": "Woonkamer",
+                "vt": "str"
+            },
+            {
+                "t": "else"
+            }
+        ],
+        "checkall": "true",
+        "repair": false,
+        "outputs": 2,
+        "x": 530,
+        "y": 900,
+        "wires": [
+            [
+                "59e9189ce22eec87"
+            ],
+            [
+                "da4a6f274ef86b0a"
+            ]
+        ]
+    },
+    {
+        "id": "59e9189ce22eec87",
+        "type": "change",
+        "z": "1044a74b4adb9c61",
+        "name": "",
+        "rules": [
+            {
+                "t": "set",
+                "p": "payload",
+                "pt": "msg",
+                "to": "msg.media_artist & \" - \" & msg.media_title",
+                "tot": "jsonata"
+            }
+        ],
+        "action": "",
+        "property": "",
+        "from": "",
+        "to": "",
+        "reg": false,
+        "x": 670,
+        "y": 800,
+        "wires": [
+            [
+                "9194324548900780",
+                "633064a13b1dde11"
+            ]
+        ]
+    },
+    {
+        "id": "9194324548900780",
+        "type": "subflow:ee7dfcae62a1d1d1",
+        "z": "1044a74b4adb9c61",
+        "name": "",
+        "x": 910,
+        "y": 760,
+        "wires": []
+    },
+    {
+        "id": "da4a6f274ef86b0a",
+        "type": "change",
+        "z": "1044a74b4adb9c61",
+        "name": "",
+        "rules": [
+            {
+                "t": "set",
+                "p": "payload",
+                "pt": "msg",
+                "to": "",
+                "tot": "str"
+            }
+        ],
+        "action": "",
+        "property": "",
+        "from": "",
+        "to": "",
+        "reg": false,
+        "x": 670,
+        "y": 840,
+        "wires": [
+            [
+                "9194324548900780"
+            ]
+        ]
+    },
+    {
+        "id": "73268ba66a7f962a",
+        "type": "function",
+        "z": "1044a74b4adb9c61",
+        "name": "concat value",
+        "func": "var appendix='value'\nmsg.topic = msg.topic.concat(appendix)\nreturn msg;",
+        "outputs": 1,
+        "noerr": 0,
+        "initialize": "",
+        "finalize": "",
+        "libs": [],
+        "x": 640,
+        "y": 940,
+        "wires": [
+            []
+        ]
+    },
+    {
+        "id": "633064a13b1dde11",
+        "type": "debug",
+        "z": "1044a74b4adb9c61",
+        "name": "debug 8",
+        "active": true,
+        "tosidebar": true,
+        "console": false,
+        "tostatus": false,
+        "complete": "false",
+        "statusVal": "",
+        "statusType": "auto",
+        "x": 1070,
+        "y": 980,
+        "wires": []
+    },
+    {
+        "id": "cdbbb3bd404d4327",
+        "type": "subflow:ee7dfcae62a1d1d1",
+        "z": "1044a74b4adb9c61",
+        "name": "",
+        "x": 1050,
+        "y": 1120,
+        "wires": []
+    },
+    {
+        "id": "4d286b6d9f925228",
+        "type": "change",
+        "z": "1044a74b4adb9c61",
+        "name": "",
+        "rules": [
+            {
+                "t": "set",
+                "p": "label",
+                "pt": "msg",
+                "to": "Gemeten",
+                "tot": "str"
+            }
+        ],
+        "action": "",
+        "property": "",
+        "from": "",
+        "to": "",
+        "reg": false,
+        "x": 510,
+        "y": 100,
+        "wires": [
+            [
+                "b5eadadbf165db94",
+                "76595fb85bdd4174"
+            ]
+        ]
+    },
+    {
+        "id": "fdb0652c84e550c2",
+        "type": "comment",
+        "z": "1044a74b4adb9c61",
+        "name": "Displayitem 1",
+        "info": "",
+        "x": 170,
+        "y": 60,
+        "wires": []
+    },
+    {
+        "id": "ab309423bbda3afd",
+        "type": "subflow:ee7dfcae62a1d1d1",
+        "z": "1044a74b4adb9c61",
+        "name": "",
+        "x": 730,
+        "y": 240,
+        "wires": []
+    },
+    {
+        "id": "f29ff5d6e8edf9ae",
+        "type": "debug",
+        "z": "1044a74b4adb9c61",
+        "name": "debug 21",
+        "active": true,
+        "tosidebar": true,
+        "console": false,
+        "tostatus": false,
+        "complete": "true",
+        "targetType": "full",
+        "statusVal": "",
+        "statusType": "auto",
+        "x": 720,
+        "y": 300,
+        "wires": []
+    },
+    {
+        "id": "ea4f1a85e58e0a3c",
+        "type": "change",
+        "z": "1044a74b4adb9c61",
+        "name": "",
+        "rules": [
+            {
+                "t": "set",
+                "p": "label",
+                "pt": "msg",
+                "to": "Ingesteld",
+                "tot": "str"
+            }
+        ],
+        "action": "",
+        "property": "",
+        "from": "",
+        "to": "",
+        "reg": false,
+        "x": 510,
+        "y": 240,
+        "wires": [
+            [
+                "ab309423bbda3afd",
+                "f29ff5d6e8edf9ae"
+            ]
+        ]
+    },
+    {
+        "id": "bac5188e1cbd80f1",
+        "type": "comment",
+        "z": "1044a74b4adb9c61",
+        "name": "Displayitem 2 (aangepast blok)",
+        "info": "",
+        "x": 230,
+        "y": 200,
+        "wires": []
+    },
+    {
+        "id": "9a23393442c5ea0c",
+        "type": "api-current-state",
+        "z": "1044a74b4adb9c61",
+        "name": "",
+        "server": "c5f56a3a.f3f838",
+        "version": 3,
+        "outputs": 1,
+        "halt_if": "",
+        "halt_if_type": "str",
+        "halt_if_compare": "is",
+        "entity_id": "sensor.delft_precipitation_forecast_total",
+        "state_type": "str",
+        "blockInputOverrides": false,
+        "outputProperties": [
+            {
+                "property": "payload",
+                "propertyType": "msg",
+                "value": "",
+                "valueType": "entityState"
+            },
+            {
+                "property": "data",
+                "propertyType": "msg",
+                "value": "",
+                "valueType": "entity"
+            }
+        ],
+        "for": "0",
+        "forType": "num",
+        "forUnits": "minutes",
+        "override_topic": false,
+        "state_location": "payload",
+        "override_payload": "msg",
+        "entity_location": "data",
+        "override_data": "msg",
+        "x": 280,
+        "y": 620,
+        "wires": [
+            []
+        ]
+    },
+    {
+        "id": "25abc7ea7f798fa2",
+        "type": "server-state-changed",
+        "z": "1044a74b4adb9c61",
+        "name": "Woonkamer temperatuur",
+        "server": "c5f56a3a.f3f838",
+        "version": 5,
+        "outputs": 1,
+        "exposeAsEntityConfig": "",
+        "entityId": "sensor.woonkamer_temperature",
+        "entityIdType": "exact",
+        "outputInitially": true,
+        "stateType": "num",
+        "ifState": "",
+        "ifStateType": "str",
+        "ifStateOperator": "is",
+        "outputOnlyOnStateChange": true,
+        "for": "0",
+        "forType": "num",
+        "forUnits": "minutes",
+        "ignorePrevStateNull": false,
+        "ignorePrevStateUnknown": false,
+        "ignorePrevStateUnavailable": false,
+        "ignoreCurrentStateUnknown": false,
+        "ignoreCurrentStateUnavailable": false,
+        "outputProperties": [
+            {
+                "property": "payload",
+                "propertyType": "msg",
+                "value": "",
+                "valueType": "entityState"
+            },
+            {
+                "property": "uom",
+                "propertyType": "msg",
+                "value": "$entity().attributes.unit_of_measurement",
+                "valueType": "jsonata"
+            },
+            {
+                "property": "label",
+                "propertyType": "msg",
+                "value": "$entity().attributes.friendly_name",
+                "valueType": "jsonata"
+            },
+            {
+                "property": "displayitem",
+                "propertyType": "msg",
+                "value": "1",
+                "valueType": "str"
+            },
+            {
+                "property": "device",
+                "propertyType": "msg",
+                "value": "wk1",
+                "valueType": "str"
+            },
+            {
+                "property": "page",
+                "propertyType": "msg",
+                "value": "main",
+                "valueType": "str"
+            }
+        ],
+        "x": 210,
+        "y": 100,
+        "wires": [
+            [
+                "4d286b6d9f925228"
+            ]
+        ]
+    },
+    {
+        "id": "199a03230e204edc",
+        "type": "server-state-changed",
+        "z": "1044a74b4adb9c61",
+        "name": "",
+        "server": "c5f56a3a.f3f838",
+        "version": 5,
+        "outputs": 1,
+        "exposeAsEntityConfig": "",
+        "entityId": "sensor.spotify_now_playing",
+        "entityIdType": "exact",
+        "outputInitially": true,
+        "stateType": "str",
+        "ifState": "",
+        "ifStateType": "str",
+        "ifStateOperator": "is",
+        "outputOnlyOnStateChange": true,
+        "for": "0",
+        "forType": "num",
+        "forUnits": "minutes",
+        "ignorePrevStateNull": false,
+        "ignorePrevStateUnknown": false,
+        "ignorePrevStateUnavailable": false,
+        "ignoreCurrentStateUnknown": false,
+        "ignoreCurrentStateUnavailable": false,
+        "outputProperties": [
+            {
+                "property": "payload",
+                "propertyType": "msg",
+                "value": "",
+                "valueType": "entityState"
+            },
+            {
+                "property": "uom",
+                "propertyType": "msg",
+                "value": "$entity().attributes.unit_of_measurement",
+                "valueType": "jsonata"
+            },
+            {
+                "property": "title",
+                "propertyType": "msg",
+                "value": "Now playing",
+                "valueType": "str"
+            },
+            {
+                "property": "source",
+                "propertyType": "msg",
+                "value": "$entity().attributes.source",
+                "valueType": "jsonata"
+            },
+            {
+                "property": "media_title",
+                "propertyType": "msg",
+                "value": "$entity().attributes.media_title",
+                "valueType": "jsonata"
+            },
+            {
+                "property": "media_artist",
+                "propertyType": "msg",
+                "value": "$entity().attributes.media_artist",
+                "valueType": "jsonata"
+            },
+            {
+                "property": "page",
+                "propertyType": "msg",
+                "value": "muziek",
+                "valueType": "str"
+            },
+            {
+                "property": "device",
+                "propertyType": "msg",
+                "value": "wk1",
+                "valueType": "str"
+            },
+            {
+                "property": "displayitem",
+                "propertyType": "msg",
+                "value": "11",
+                "valueType": "str"
+            }
+        ],
+        "x": 230,
+        "y": 820,
+        "wires": [
+            [
+                "9c81d00921e7a289",
+                "0673d76b8e2c2b11"
+            ]
+        ]
+    },
+    {
+        "id": "74f02ff1ad5a5726",
+        "type": "server-state-changed",
+        "z": "1044a74b4adb9c61",
+        "name": "",
+        "server": "c5f56a3a.f3f838",
+        "version": 5,
+        "outputs": 1,
+        "exposeAsEntityConfig": "",
+        "entityId": "sensor.buienalarm_precipitation_forecast_total",
+        "entityIdType": "exact",
+        "outputInitially": true,
+        "stateType": "num",
+        "ifState": "",
+        "ifStateType": "str",
+        "ifStateOperator": "is",
+        "outputOnlyOnStateChange": true,
+        "for": "",
+        "forType": "num",
+        "forUnits": "minutes",
+        "ignorePrevStateNull": false,
+        "ignorePrevStateUnknown": false,
+        "ignorePrevStateUnavailable": false,
+        "ignoreCurrentStateUnknown": false,
+        "ignoreCurrentStateUnavailable": false,
+        "outputProperties": [
+            {
+                "property": "payload",
+                "propertyType": "msg",
+                "value": "",
+                "valueType": "entityState"
+            },
+            {
+                "property": "uom",
+                "propertyType": "msg",
+                "value": "$entity().attributes.unit_of_measurement",
+                "valueType": "jsonata"
+            },
+            {
+                "property": "title",
+                "propertyType": "msg",
+                "value": "Regen 15min",
+                "valueType": "str"
+            },
+            {
+                "property": "topic",
+                "propertyType": "msg",
+                "value": "buttonplus/wk1/main/in/5/",
+                "valueType": "str"
+            },
+            {
+                "property": "page",
+                "propertyType": "msg",
+                "value": "ochtend",
+                "valueType": "str"
+            },
+            {
+                "property": "device",
+                "propertyType": "msg",
+                "value": "wk1",
+                "valueType": "str"
+            },
+            {
+                "property": "displayitem",
+                "propertyType": "msg",
+                "value": "10",
+                "valueType": "str"
+            }
+        ],
+        "x": 240,
+        "y": 1060,
+        "wires": [
+            [
+                "708d814b09a36bd2"
+            ]
+        ]
+    },
+    {
+        "id": "7f2d36bb6cd2f0de",
+        "type": "server-state-changed",
+        "z": "1044a74b4adb9c61",
+        "name": "Ingestelde temperatuur",
+        "server": "c5f56a3a.f3f838",
+        "version": 5,
+        "outputs": 1,
+        "exposeAsEntityConfig": "",
+        "entityId": "climate.woonkamer",
+        "entityIdType": "exact",
+        "outputInitially": true,
+        "stateType": "num",
+        "ifState": "",
+        "ifStateType": "str",
+        "ifStateOperator": "is",
+        "outputOnlyOnStateChange": false,
+        "for": "0",
+        "forType": "num",
+        "forUnits": "minutes",
+        "ignorePrevStateNull": false,
+        "ignorePrevStateUnknown": false,
+        "ignorePrevStateUnavailable": false,
+        "ignoreCurrentStateUnknown": false,
+        "ignoreCurrentStateUnavailable": false,
+        "outputProperties": [
+            {
+                "property": "payload",
+                "propertyType": "msg",
+                "value": "$entity().attributes.temperature",
+                "valueType": "jsonata"
+            },
+            {
+                "property": "uom",
+                "propertyType": "msg",
+                "value": "$entity().attributes.unit_of_measurement",
+                "valueType": "jsonata"
+            },
+            {
+                "property": "label",
+                "propertyType": "msg",
+                "value": "$entity().attributes.friendly_name",
+                "valueType": "jsonata"
+            },
+            {
+                "property": "displayitem",
+                "propertyType": "msg",
+                "value": "2",
+                "valueType": "str"
+            },
+            {
+                "property": "device",
+                "propertyType": "msg",
+                "value": "wk1",
+                "valueType": "str"
+            },
+            {
+                "property": "page",
+                "propertyType": "msg",
+                "value": "main",
+                "valueType": "str"
+            }
+        ],
+        "x": 200,
+        "y": 240,
+        "wires": [
+            [
+                "ea4f1a85e58e0a3c"
+            ]
+        ]
+    },
+    {
+        "id": "ae778fc259e59470",
+        "type": "subflow:ee7dfcae62a1d1d1",
+        "z": "1044a74b4adb9c61",
+        "name": "",
+        "x": 730,
+        "y": 440,
+        "wires": []
+    },
+    {
+        "id": "f4d3696a8f6a19fa",
+        "type": "debug",
+        "z": "1044a74b4adb9c61",
+        "name": "debug 25",
+        "active": true,
+        "tosidebar": true,
+        "console": false,
+        "tostatus": false,
+        "complete": "true",
+        "targetType": "full",
+        "statusVal": "",
+        "statusType": "auto",
+        "x": 720,
+        "y": 500,
+        "wires": []
+    },
+    {
+        "id": "b5d0fe5ee189f94f",
+        "type": "change",
+        "z": "1044a74b4adb9c61",
+        "name": "",
+        "rules": [
+            {
+                "t": "set",
+                "p": "device",
+                "pt": "msg",
+                "to": "wk1",
+                "tot": "str"
+            },
+            {
+                "t": "set",
+                "p": "displayitem",
+                "pt": "msg",
+                "to": "3",
+                "tot": "str"
+            }
+        ],
+        "action": "",
+        "property": "",
+        "from": "",
+        "to": "",
+        "reg": false,
+        "x": 520,
+        "y": 440,
+        "wires": [
+            [
+                "ae778fc259e59470"
+            ]
+        ]
+    },
+    {
+        "id": "894ba0312a96aadb",
+        "type": "comment",
+        "z": "1044a74b4adb9c61",
+        "name": "Displayitem 6 (aangepast blok)",
+        "info": "",
+        "x": 230,
+        "y": 400,
+        "wires": []
+    },
+    {
+        "id": "c4590a066bf2df4f",
+        "type": "server-state-changed",
+        "z": "1044a74b4adb9c61",
+        "name": "Tijd",
+        "server": "c5f56a3a.f3f838",
+        "version": 5,
+        "outputs": 1,
+        "exposeAsEntityConfig": "",
+        "entityId": "sensor.time",
+        "entityIdType": "exact",
+        "outputInitially": true,
+        "stateType": "str",
+        "ifState": "",
+        "ifStateType": "str",
+        "ifStateOperator": "is",
+        "outputOnlyOnStateChange": true,
+        "for": "0",
+        "forType": "num",
+        "forUnits": "minutes",
+        "ignorePrevStateNull": false,
+        "ignorePrevStateUnknown": false,
+        "ignorePrevStateUnavailable": false,
+        "ignoreCurrentStateUnknown": false,
+        "ignoreCurrentStateUnavailable": false,
+        "outputProperties": [
+            {
+                "property": "payload",
+                "propertyType": "msg",
+                "value": "",
+                "valueType": "entityState"
+            },
+            {
+                "property": "displayitem",
+                "propertyType": "msg",
+                "value": "6",
+                "valueType": "str"
+            },
+            {
+                "property": "device",
+                "propertyType": "msg",
+                "value": "wk1",
+                "valueType": "str"
+            },
+            {
+                "property": "page",
+                "propertyType": "msg",
+                "value": "main",
+                "valueType": "str"
+            }
+        ],
+        "x": 150,
+        "y": 440,
+        "wires": [
+            [
+                "b5d0fe5ee189f94f"
+            ]
+        ]
+    },
+    {
+        "id": "9bcaa6cdef2cc259",
+        "type": "server-state-changed",
+        "z": "1044a74b4adb9c61",
+        "name": "Datum",
+        "server": "c5f56a3a.f3f838",
+        "version": 5,
+        "outputs": 1,
+        "exposeAsEntityConfig": "",
+        "entityId": "sensor.date",
+        "entityIdType": "exact",
+        "outputInitially": true,
+        "stateType": "str",
+        "ifState": "",
+        "ifStateType": "str",
+        "ifStateOperator": "is",
+        "outputOnlyOnStateChange": true,
+        "for": "0",
+        "forType": "num",
+        "forUnits": "minutes",
+        "ignorePrevStateNull": false,
+        "ignorePrevStateUnknown": false,
+        "ignorePrevStateUnavailable": false,
+        "ignoreCurrentStateUnknown": false,
+        "ignoreCurrentStateUnavailable": false,
+        "outputProperties": [
+            {
+                "property": "label",
+                "propertyType": "msg",
+                "value": "",
+                "valueType": "entityState"
+            },
+            {
+                "property": "displayitem",
+                "propertyType": "msg",
+                "value": "6",
+                "valueType": "str"
+            },
+            {
+                "property": "device",
+                "propertyType": "msg",
+                "value": "wk1",
+                "valueType": "str"
+            },
+            {
+                "property": "page",
+                "propertyType": "msg",
+                "value": "main",
+                "valueType": "str"
+            }
+        ],
+        "x": 150,
+        "y": 500,
+        "wires": [
+            [
+                "b6cae6645fc1100d"
+            ]
+        ]
+    },
+    {
+        "id": "b6cae6645fc1100d",
+        "type": "moment",
+        "z": "1044a74b4adb9c61",
+        "name": "format date",
+        "topic": "",
+        "input": "label",
+        "inputType": "msg",
+        "inTz": "Europe/Amsterdam",
+        "adjAmount": 0,
+        "adjType": "days",
+        "adjDir": "add",
+        "format": "D MMMM",
+        "locale": "nl",
+        "output": "label",
+        "outputType": "msg",
+        "outTz": "Europe/Amsterdam",
+        "x": 290,
+        "y": 500,
+        "wires": [
+            [
+                "b5d0fe5ee189f94f"
+            ]
+        ]
+    },
+    {
+        "id": "4a7e09d84565482f",
+        "type": "function",
+        "z": "1044a74b4adb9c61",
+        "name": "mm naar voorspelling",
+        "func": "var mmpu = msg.payload*4;\nvar description;\nif (mmpu ==0){\n    description = \"(droog)\";\n} else if (mmpu < 1) {\n    description = \"(licht)\";\n} else if (mmpu < 5) {\n    description = \"(matig)\";\n} else {\n    description = \"(zwaar)\";\n}\nmsg.payload = mmpu.toString()+\" mm/u \"+description;\nreturn msg;",
+        "outputs": 1,
+        "timeout": 0,
+        "noerr": 0,
+        "initialize": "",
+        "finalize": "",
+        "libs": [],
+        "x": 800,
+        "y": 1120,
+        "wires": [
+            [
+                "cdbbb3bd404d4327"
+            ]
+        ]
+    },
+    {
+        "id": "708d814b09a36bd2",
+        "type": "change",
+        "z": "1044a74b4adb9c61",
+        "name": "",
+        "rules": [
+            {
+                "t": "set",
+                "p": "label",
+                "pt": "msg",
+                "to": "Regen komende 15 min",
+                "tot": "str"
+            },
+            {
+                "t": "set",
+                "p": "payload",
+                "pt": "msg",
+                "to": "$number(payload)",
+                "tot": "jsonata"
+            },
+            {
+                "t": "set",
+                "p": "uom",
+                "pt": "msg",
+                "to": "",
+                "tot": "str"
+            }
+        ],
+        "action": "",
+        "property": "",
+        "from": "",
+        "to": "",
+        "reg": false,
+        "x": 800,
+        "y": 1060,
+        "wires": [
+            [
+                "4a7e09d84565482f"
+            ]
+        ]
+    },
+    {
+        "id": "4e09035911d2e244",
+        "type": "server-state-changed",
+        "z": "1044a74b4adb9c61",
+        "name": "",
+        "server": "c5f56a3a.f3f838",
+        "version": 5,
+        "outputs": 1,
+        "exposeAsEntityConfig": "",
+        "entityId": "sensor.buttonplus_prio_notification",
+        "entityIdType": "exact",
+        "outputInitially": true,
+        "stateType": "str",
+        "ifState": "",
+        "ifStateType": "str",
+        "ifStateOperator": "is",
+        "outputOnlyOnStateChange": true,
+        "for": "0",
+        "forType": "num",
+        "forUnits": "minutes",
+        "ignorePrevStateNull": false,
+        "ignorePrevStateUnknown": false,
+        "ignorePrevStateUnavailable": false,
+        "ignoreCurrentStateUnknown": false,
+        "ignoreCurrentStateUnavailable": false,
+        "outputProperties": [
+            {
+                "property": "payload",
+                "propertyType": "msg",
+                "value": "",
+                "valueType": "entityState"
+            },
+            {
+                "property": "data",
+                "propertyType": "msg",
+                "value": "",
+                "valueType": "eventData"
+            },
+            {
+                "property": "topic",
+                "propertyType": "msg",
+                "value": "",
+                "valueType": "triggerId"
+            },
+            {
+                "property": "label",
+                "propertyType": "msg",
+                "value": "$entity(). attributes.label",
+                "valueType": "jsonata"
+            },
+            {
+                "property": "toplabel",
+                "propertyType": "msg",
+                "value": "$entity().attributes.toplabel",
+                "valueType": "jsonata"
+            },
+            {
+                "property": "ledrgb",
+                "propertyType": "msg",
+                "value": "$entity().attributes.frontled",
+                "valueType": "jsonata"
+            },
+            {
+                "property": "topic",
+                "propertyType": "msg",
+                "value": "buttonplus/wk1/button/main/2",
+                "valueType": "str"
+            }
+        ],
+        "x": 210,
+        "y": 1240,
+        "wires": [
+            [
+                "c9a98ceba76c6c47",
+                "52071c63d9f364d1"
+            ]
+        ]
+    },
+    {
+        "id": "c9a98ceba76c6c47",
+        "type": "function",
+        "z": "1044a74b4adb9c61",
+        "name": "prepare MQTT topics",
+        "func": "function sleep(ms) {\n    return new Promise((resolve) => {\n        setTimeout(resolve, ms);\n    });\n}\n\nvar newMsg = {};\n// send label\nnewMsg.payload = msg.label;\nif (newMsg.payload == \"\") { newMsg.payload = \" \" }\nnewMsg.topic = msg.topic+\"/label\";\nnode.send(newMsg);\nawait sleep(20);\n\n// send toplabel\nnewMsg.payload = msg.toplabel;\nif (newMsg.payload == \"\") { newMsg.payload = \" \" }\nnewMsg.topic = msg.topic+\"/toplabel\";\nnode.send(newMsg);\nawait sleep(20);\n// send led color\nnewMsg.payload = msg.ledrgb;\nnewMsg.topic = msg.topic+\"/ledrgb\";\nnode.send(newMsg);\nawait sleep(20);\n// send led state\n// newMsg.payload = msg.led[i];\n// newMsg.topic = msg.topic + i + \"/led\";\n// node.send(newMsg);\n\n\n\nreturn null;",
+        "outputs": 1,
+        "timeout": 0,
+        "noerr": 0,
+        "initialize": "",
+        "finalize": "",
+        "libs": [],
+        "x": 540,
+        "y": 1240,
+        "wires": [
+            [
+                "bda2c11f55cdc105"
+            ]
+        ]
+    },
+    {
+        "id": "bda2c11f55cdc105",
+        "type": "mqtt out",
+        "z": "1044a74b4adb9c61",
+        "name": "Update buttons",
+        "topic": "",
+        "qos": "2",
+        "retain": "true",
+        "respTopic": "",
+        "contentType": "",
+        "userProps": "",
+        "correl": "",
+        "expiry": "",
+        "broker": "e6dbd5fb3f32ec20",
+        "x": 760,
+        "y": 1240,
+        "wires": []
+    },
+    {
+        "id": "52071c63d9f364d1",
+        "type": "debug",
+        "z": "1044a74b4adb9c61",
+        "name": "debug 27",
+        "active": true,
+        "tosidebar": true,
+        "console": false,
+        "tostatus": false,
+        "complete": "false",
+        "statusVal": "",
+        "statusType": "auto",
+        "x": 560,
+        "y": 1320,
+        "wires": []
+    },
+    {
+        "id": "0673d76b8e2c2b11",
+        "type": "change",
+        "z": "1044a74b4adb9c61",
+        "name": "",
+        "rules": [
+            {
+                "t": "set",
+                "p": "label",
+                "pt": "msg",
+                "to": "Wat speelt er nu?",
+                "tot": "str"
+            }
+        ],
+        "action": "",
+        "property": "",
+        "from": "",
+        "to": "",
+        "reg": false,
+        "x": 530,
+        "y": 760,
+        "wires": [
+            [
+                "9194324548900780"
+            ]
+        ]
+    },
+    {
+        "id": "c5f56a3a.f3f838",
+        "type": "server",
+        "name": "Home Assistant",
+        "version": 5,
+        "addon": true,
+        "rejectUnauthorizedCerts": true,
+        "ha_boolean": "y|yes|true|on|home|open",
+        "connectionDelay": true,
+        "cacheJson": true,
+        "heartbeat": false,
+        "heartbeatInterval": "30",
+        "areaSelector": "friendlyName",
+        "deviceSelector": "friendlyName",
+        "entitySelector": "friendlyName",
+        "statusSeparator": "at: ",
+        "statusYear": "hidden",
+        "statusMonth": "short",
+        "statusDay": "numeric",
+        "statusHourCycle": "h23",
+        "statusTimeFormat": "h:m",
+        "enableGlobalContextStore": true
+    }
+]


### PR DESCRIPTION
Complete rewrite of flow; switching to a new page now uploads a complete JSON to the B+
Button topics (labels, clicks, everything) are now specific to a (menu)page. For instance `buttonplus/wk1/button/music/7/state` is publishing clicks from button number 7 (bottom right with 3 bars) but only for the page `music`. The backend does not need to be aware of the state of the B+ menu; you can simply use this topic and assign it to an action, such as `Volume Up`. The topic disappears when another page is active.